### PR TITLE
Mounted by is a string, not number

### DIFF
--- a/cli/command/formatter/volume.go
+++ b/cli/command/formatter/volume.go
@@ -93,7 +93,7 @@ func (c *volumeContext) MountedBy() string {
 	if c.v.MountedBy == "" {
 		return ""
 	}
-	return fmt.Sprintf("%d", c.v.MountedBy)
+	return fmt.Sprintf("%s", c.v.MountedBy)
 }
 
 func (c *volumeContext) Size() string {


### PR DESCRIPTION
Fixes:

```
$ storageos volume ls
NAMESPACE/NAME      SIZE                MOUNTED BY              STATUS
default/pv0001      5 GB                %!d(string=127.0.0.1)   deleting
```