### PR TITLE
Fix bad groups formatting and update deps

### DIFF
--- a/cli/command/user/update.go
+++ b/cli/command/user/update.go
@@ -43,7 +43,7 @@ func (u updateOptions) processGroups(current []string) []string {
 
 	// remove groups
 	for _, v := range current {
-		if !needsRemoval(v) {
+		if !needsRemoval(v) && v != "" {
 			newGroups = append(newGroups, v)
 		}
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: ecd0713d1ed125ef6eab523210aa38ef2630f05db7ad27499f22960a17b1c0db
-updated: 2017-07-28T12:33:39.371672425+01:00
+updated: 2017-08-01T15:11:18.478964361+01:00
 imports:
 - name: github.com/Azure/go-ansiterm
   version: 19f72df4d05d31cbe1c56bfc8045c96babff6c7e
@@ -30,12 +30,12 @@ imports:
 - name: github.com/spf13/pflag
   version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
 - name: github.com/storageos/go-api
-  version: 584064217d9911890042c647f7bc68d038e6acab
+  version: c7d11f85f6e1e708f7db1813756156ce3d48f0b8
   subpackages:
   - types
   - types/versions
 - name: golang.org/x/crypto
-  version: 27b9897dfcda296fc086003b6e46fca80a29512d
+  version: 558b6879de74bc843225cde5686419267ff707ca
   subpackages:
   - ssh
   - ssh/terminal

--- a/vendor/github.com/storageos/go-api/types/user.go
+++ b/vendor/github.com/storageos/go-api/types/user.go
@@ -63,7 +63,7 @@ type UserCreateOptions struct {
 	Context context.Context `json:"-"`
 }
 
-func (u *UserCreateOptions) MarshalJSON() ([]byte, error) {
+func (u UserCreateOptions) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		Username string `json:"username"`
 		Groups   string `json:"groups"`

--- a/vendor/golang.org/x/crypto/ssh/terminal/util_bsd.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/util_bsd.go
@@ -6,7 +6,7 @@
 
 package terminal
 
-import "syscall"
+import "golang.org/x/sys/unix"
 
-const ioctlReadTermios = syscall.TIOCGETA
-const ioctlWriteTermios = syscall.TIOCSETA
+const ioctlReadTermios = unix.TIOCGETA
+const ioctlWriteTermios = unix.TIOCSETA

--- a/vendor/golang.org/x/crypto/ssh/terminal/util_linux.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/util_linux.go
@@ -4,8 +4,7 @@
 
 package terminal
 
-// These constants are declared here, rather than importing
-// them from the syscall package as some syscall packages, even
-// on linux, for example gccgo, do not declare them.
-const ioctlReadTermios = 0x5401  // syscall.TCGETS
-const ioctlWriteTermios = 0x5402 // syscall.TCSETS
+import "golang.org/x/sys/unix"
+
+const ioctlReadTermios = unix.TCGETS
+const ioctlWriteTermios = unix.TCSETS


### PR DESCRIPTION
In some edge-cases extra "," separators were seen in group fields.
This change fixes this behaviour.