### PR TITLE
Feature/dev 1579 nicer http errors

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 0d9d99619eee5f5905d352d3177e375dca188b43c96b77df95d139ce32e4e265
-updated: 2017-08-11T15:36:22.552087393+01:00
+updated: 2017-08-11T15:50:37.051663614+01:00
 imports:
 - name: github.com/Azure/go-ansiterm
   version: 19f72df4d05d31cbe1c56bfc8045c96babff6c7e
@@ -31,7 +31,7 @@ imports:
 - name: github.com/spf13/pflag
   version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
 - name: github.com/storageos/go-api
-  version: 139d85d70bb7563155e31e0209ac7083ff41d01d
+  version: 143777bbe9b481cbfce9e53244fd7d89ec802655
   subpackages:
   - types
   - types/versions

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 0d9d99619eee5f5905d352d3177e375dca188b43c96b77df95d139ce32e4e265
-updated: 2017-08-11T12:13:59.735206344+01:00
+updated: 2017-08-11T15:36:22.552087393+01:00
 imports:
 - name: github.com/Azure/go-ansiterm
   version: 19f72df4d05d31cbe1c56bfc8045c96babff6c7e
@@ -31,7 +31,7 @@ imports:
 - name: github.com/spf13/pflag
   version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
 - name: github.com/storageos/go-api
-  version: 22bf9e5a0f1812859a1be6dfd4d7a032e661aecd
+  version: 139d85d70bb7563155e31e0209ac7083ff41d01d
   subpackages:
   - types
   - types/versions

--- a/vendor/github.com/storageos/go-api/client.go
+++ b/vendor/github.com/storageos/go-api/client.go
@@ -553,9 +553,9 @@ func (e *Error) Error() string {
 	}
 
 	if niceStatus != "" {
-		return fmt.Sprintf("API error (%d): %s", niceStatus, e.Message)
+		return fmt.Sprintf("API error (%s): %s", niceStatus, e.Message)
 	}
-	return fmt.Sprintf("API error (%d): %s", http.StatusText(e.Status), e.Message)
+	return fmt.Sprintf("API error (%s): %s", http.StatusText(e.Status), e.Message)
 }
 
 func parseEndpoint(endpoint string, tls bool) (*url.URL, error) {

--- a/vendor/github.com/storageos/go-api/client.go
+++ b/vendor/github.com/storageos/go-api/client.go
@@ -539,7 +539,23 @@ func newError(resp *http.Response) *Error {
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("API error (%d): %s", e.Status, e.Message)
+	var niceStatus string
+
+	switch e.Status {
+	case 400, 500:
+		niceStatus = "Server failed to process your request. Was the data correct?"
+	case 401:
+		niceStatus = "Unauthenticated access of secure endpoint, please retry after authentication"
+	case 403:
+		niceStatus = "Forbidden request. Your user cannot perform this action"
+	case 404:
+		niceStatus = "Requested object not found. Does this item exist?"
+	}
+
+	if niceStatus != "" {
+		return fmt.Sprintf("API error (%d): %s", niceStatus, e.Message)
+	}
+	return fmt.Sprintf("API error (%d): %s", http.StatusText(e.Status), e.Message)
 }
 
 func parseEndpoint(endpoint string, tls bool) (*url.URL, error) {


### PR DESCRIPTION
This change adds some basic formatting to the API class of errors.

In known cases the errors are provided in the form of full sentences explaining the bug.
In unknown cases, the name of the HTTP status is returned instead of a status code.

Hopefully this will make the errors more readable and actionable for a user.