### PR TITLE
Cluster validation

### DIFF
--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/storageos/go-cli/cli"
 	"github.com/storageos/go-cli/cli/command"
+	"github.com/storageos/go-cli/cli/opts"
 
 	"github.com/storageos/go-cli/discovery"
 )
@@ -38,11 +39,15 @@ func newCreateCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 	flags.StringVar(&opt.name, "name", "", "Cluster name")
 	flags.Lookup("name").Hidden = true
 
-	flags.IntVarP(&opt.size, "size", "s", 3, "Cluster size (3-7)")
+	flags.IntVarP(&opt.size, "size", "s", 3, "Cluster consensus size: 1, 3, 5, or 7 (minimum 3 for production)")
 	return cmd
 }
 
 func runCreate(storageosCli *command.StorageOSCli, opt createOptions) error {
+
+	if _, err := opts.ValidateClusterSize(opt.size); err != nil {
+		return err
+	}
 
 	client, err := discovery.NewClient("", "", "")
 	if err != nil {

--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -54,6 +54,6 @@ func runCreate(storageosCli *command.StorageOSCli, opt createOptions) error {
 		return err
 	}
 
-	fmt.Fprintf(storageosCli.Out(), "cluster token: %s\n", token)
+	fmt.Fprintf(storageosCli.Out(), "%s\n", token)
 	return nil
 }

--- a/cli/opts/cluster.go
+++ b/cli/opts/cluster.go
@@ -1,0 +1,13 @@
+package opts
+
+import "fmt"
+
+// ValidateClusterSize validates whether the input string is a valid cluster size.
+func ValidateClusterSize(val int) (int, error) {
+	switch val {
+	case 1, 3, 5, 7:
+		return val, nil
+	default:
+		return 0, fmt.Errorf("cluster consensus size must be one of %d, %d, %d, or %d (minimum 3 for production)", 1, 3, 5, 7)
+	}
+}

--- a/cli/opts/cluster_test.go
+++ b/cli/opts/cluster_test.go
@@ -1,0 +1,36 @@
+package opts
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestValidateClusterSize(t *testing.T) {
+
+	e := fmt.Errorf("some error")
+	var tests = []struct {
+		input       int
+		expected    int
+		expectedErr error
+	}{
+		{1, 1, nil},
+		{3, 3, nil},
+		{5, 5, nil},
+		{7, 7, nil},
+		{0, 0, e},
+		{2, 0, e},
+		{4, 0, e},
+		{6, 0, e},
+		{8, 0, e},
+		{100, 0, e},
+	}
+	for _, tt := range tests {
+		output, err := ValidateClusterSize(tt.input)
+		if err != nil && tt.expectedErr == nil {
+			t.Errorf("ValidateOperator(%d): Got unexpected error %d.", tt.input, err)
+		}
+		if output != tt.expected {
+			t.Errorf("ValidateOperator(%d): Got %d. Want %d.", tt.input, output, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
Validates cluster size and removes prefix from cluster create output (none of the other create commands label the output)