### PR TITLE
Validate root for mounts

### DIFF
--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -54,6 +54,6 @@ func runCreate(storageosCli *command.StorageOSCli, opt createOptions) error {
 		return err
 	}
 
-	fmt.Fprintf(storageosCli.Out(), "cluster token: %s\n", token)
+	fmt.Fprintf(storageosCli.Out(), "%s\n", token)
 	return nil
 }

--- a/cli/command/volume/mount_linux.go
+++ b/cli/command/volume/mount_linux.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/dnephin/cobra"
@@ -54,7 +55,12 @@ func runMount(storageosCli *command.StorageOSCli, opt mountOptions) error {
 	// checking whether we are on storageos node
 	_, err := system.Stat(cliconfig.DeviceRootPath)
 	if err != nil {
-		return fmt.Errorf("device root path '%s' not found, check whether StorageOS is running", cliconfig.DeviceRootPath)
+		return fmt.Errorf("device root path %q not found, check whether StorageOS is running", cliconfig.DeviceRootPath)
+	}
+
+	// must be root
+	if euid := syscall.Geteuid(); euid != 0 {
+		return fmt.Errorf("volume mount requires root permission - try prefixing command with `sudo`")
 	}
 
 	// validating fsType

--- a/cli/command/volume/unmount_linux.go
+++ b/cli/command/volume/unmount_linux.go
@@ -5,6 +5,7 @@ package volume
 import (
 	"context"
 	"fmt"
+	"syscall"
 	// "strings"
 	"time"
 
@@ -54,6 +55,11 @@ func runUnmount(storageosCli *command.StorageOSCli, opt unmountOptions, mountDri
 	_, err := system.Stat(cliconfig.DeviceRootPath)
 	if err != nil {
 		return fmt.Errorf("device root path '%s' not found, check whether StorageOS is running", cliconfig.DeviceRootPath)
+	}
+
+	// must be root
+	if euid := syscall.Geteuid(); euid != 0 {
+		return fmt.Errorf("volume unmount must be run as root user - try prefixing command with `sudo`")
 	}
 
 	client := storageosCli.Client()


### PR DESCRIPTION
Fixes:

```
ERRO[0000]  failed to mount volume                       err="mkdir /mnt: permission denied" mountpoint=/mnt volume_id=8c2a1ba7-f094-6a9b-11ba-8216e1f420f6
```

Now:
```
$ storageos volume mount default/test02 /mnt
volume mount requires root permission - try prefixing command with `sudo`

$ sudo STORAGEOS_USERNAME=storageos STORAGEOS_PASSWORD=XXXXX storageos volume mount default/test02 /mnt
volume test02 mounted: /mnt

$ storageos volume unmount default/test02
volume unmount must be run as root user - try prefixing command with `sudo`
$ sudo STORAGEOS_USERNAME=storageos STORAGEOS_PASSWORD=XXXXX storageos volume unmount default/test02
volume test02 unmounted: /mnt
```
