### PR TITLE
Use default host on login by default

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -95,7 +95,6 @@ func (cli *StorageOSCli) Initialize(opt *cliflags.ClientOptions) error {
 	cli.configFile = LoadDefaultConfigFile(cli.err)
 
 	var err error
-	// cli.client, err = NewAPIClientFromFlags(opts.Common, cli.configFile)
 	cli.client, err = NewAPIClientFromFlags(opt.Common, cli.configFile)
 	if err != nil {
 		return err
@@ -187,14 +186,6 @@ func NewAPIClientFromFlags(opt *cliflags.CommonOptions, configFile *configfile.C
 	}
 	if opt.Password != "" {
 		password = opt.Password
-	}
-
-	// If after everything is tried, we still don't have any creds, just try the defaults
-	if username == "" {
-		username = api.DefaultUsername
-	}
-	if password == "" {
-		password = api.DefaultUsername
 	}
 
 	if username != "" && password != "" {

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -189,6 +189,14 @@ func NewAPIClientFromFlags(opt *cliflags.CommonOptions, configFile *configfile.C
 		password = opt.Password
 	}
 
+	// If after everything is tried, we still don't have any creds, just try the defaults
+	if username == "" {
+		username = api.DefaultUsername
+	}
+	if password == "" {
+		password = api.DefaultUsername
+	}
+
 	if username != "" && password != "" {
 		client.SetAuth(username, password)
 	}

--- a/cli/command/login/cmd.go
+++ b/cli/command/login/cmd.go
@@ -78,7 +78,7 @@ func getHost(opt loginOptions, args []string) (string, error) {
 	default:
 		host = os.Getenv(config.EnvStorageOSHost)
 		if host == "" {
-			return "", errors.New("No setting found for host")
+			return validation.ParseHostPort(api.DefaultHost, api.DefaultPort)
 		}
 
 	}

--- a/cli/command/logout/cmd.go
+++ b/cli/command/logout/cmd.go
@@ -51,7 +51,7 @@ func getHost(opt logoutOptions, args []string) (string, error) {
 	default:
 		host = os.Getenv(config.EnvStorageOSHost)
 		if host == "" {
-			return "", errors.New("No setting found for host")
+			return validation.ParseHostPort(api.DefaultHost, api.DefaultPort)
 		}
 
 	}


### PR DESCRIPTION
Adds extra behaviour to the CLI to use default host on login when no host was provided.