### PR TITLE
Reducing version timeout

### DIFF
--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -57,7 +57,8 @@ func NewVersionCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 }
 
 func runVersion(storageosCli *command.StorageOSCli, opts *versionOptions) error {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 
 	templateFormat := versionTemplate
 	if opts.format != "" {


### PR DESCRIPTION
There will be a global change made to the API regarding dialer timeouts.
However the version command probably requires an even shorter timeout.

Fixes #55 when paired with https://github.com/storageos/go-api/pull/29