### PR TITLE
sort cluster health node list by name

### DIFF
--- a/cli/command/cluster/health.go
+++ b/cli/command/cluster/health.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"sort"
 	"time"
 
 	"github.com/dnephin/cobra"
@@ -61,6 +62,7 @@ func runHealth(storageosCli *command.StorageOSCli, opt *healthOpt) error {
 		}
 	}
 
+	sort.Sort(cliTypes.NodeByName(nodes))
 	for _, node := range nodes {
 		if err := runNodeHealth(storageosCli, node, opt.timeout); err != nil {
 			return err

--- a/types/types.go
+++ b/types/types.go
@@ -47,3 +47,10 @@ type Node struct {
 		DP *apiTypes.DPHealthStatus
 	}
 }
+
+// NodeByName sorts node list by hostname
+type NodeByName []*Node
+
+func (n NodeByName) Len() int           { return len(n) }
+func (n NodeByName) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+func (n NodeByName) Less(i, j int) bool { return n[i].Name < n[j].Name }


### PR DESCRIPTION
Add sorting by node name to cluster health so it works better when using `watch storageos cluster health` to monitor status