### PR TITLE
makefile: release file hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,7 @@ release:
 	go get github.com/mitchellh/gox
 	cd cmd/storageos && gox -verbose -output="release/{{.Dir}}_{{.OS}}_{{.Arch}}" \
 		-ldflags "$(LDFLAGS)" -osarch="linux/amd64 darwin/amd64 windows/amd64"
+	@rm -f cmd/storageos/release/*.sha256
+	@for filename in cmd/storageos/release/*; do \
+		shasum -a 256 $$filename > $$filename.sha256; \
+	done;


### PR DESCRIPTION
This change amends make's `release` target to generate file hashes of all
the generated binaries. This would result in publishing binaries with their
hashes for data integrity verification.