### PR TITLE
Only use valid cluster IDs

### DIFF
--- a/cli/command/cluster/inspect.go
+++ b/cli/command/cluster/inspect.go
@@ -1,8 +1,9 @@
 package cluster
 
 import (
+	"fmt"
 	"github.com/dnephin/cobra"
-	// storageos "github.com/storageos/go-api"
+	api "github.com/storageos/go-api"
 	"github.com/storageos/go-cli/cli"
 	"github.com/storageos/go-cli/cli/command"
 	"github.com/storageos/go-cli/cli/command/inspect"
@@ -42,6 +43,10 @@ func runInspect(storageosCli *command.StorageOSCli, opt inspectOptions) error {
 	}
 
 	getFunc := func(ref string) (interface{}, []byte, error) {
+		if !api.IsUUID(ref) {
+			return nil, nil, fmt.Errorf("invalid cluster token (%v)", ref)
+		}
+
 		i, err := client.ClusterStatus(ref)
 		return i, nil, err
 	}

--- a/discovery/client.go
+++ b/discovery/client.go
@@ -161,6 +161,17 @@ func (c *Client) ClusterStatus(id string) (*types.Cluster, error) {
 	}
 	defer resp.Body.Close()
 
+	switch resp.StatusCode {
+	case http.StatusOK:
+		break // just continue normally
+
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("unknown cluster key (%v)", id)
+
+	default:
+		return nil, fmt.Errorf("API error, unknown status (%v)", resp.Status)
+	}
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Command now returns an error id the given CID is not a UUID

Adds error handling for 404 errors (e.g. when a UUID id given, but not a
known token)

Adds error handling for unknown status responses from the discovery
service