### PR TITLE
Add Makefile target to build and install into GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ build:
 	@echo "++ Building storageos binary"
 	cd cmd/storageos && CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)"
 
+install:
+	@echo "++ Installing storageos binary into \$GOPATH/bin"
+	touch version/client.go && go install -ldflags "$(LDFLAGS)" github.com/storageos/go-cli/cmd/storageos
+
 release:
 	@echo "++ Building storageos release binaries"
 	go get github.com/mitchellh/gox

--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ Checkout `go-cli` into your `GOPATH`.  Consult https://github.com/golang/go/wiki
 go get -d github.com/storageos/go-cli/...
 ```
 
+### Build & install local binary into $GOPATH/bin
+
+```bash
+cd $GOPATH/src/github.com/storageos/go-cli
+make install
+```
+
+The binary will be in `$GOPATH/bin/storageos`
+
 ### Building local binary
 
 ```bash


### PR DESCRIPTION
Saves having to copy the binary into your path when developing.

The `touch version/client.go` just makes sure you're rebuilding it.