### PR TITLE
Update some old label values

### DIFF
--- a/cli/command/formatter/volume.go
+++ b/cli/command/formatter/volume.go
@@ -166,7 +166,7 @@ func activeReplicas(volume *types.Volume) int {
 }
 
 // GetDesiredReplicas - get desired replicas.
-// If the value is invalid (i.e. storageos.feature.replicas="hi") - desired
+// If the value is invalid (i.e. storageos.com/replicas="hi") - desired
 // replicas will be set to 0. Only valid values will be tolerated.
 func getDesiredReplicas(volume *types.Volume) int {
 	r, ok := volume.Labels[cliconfig.FeatureReplicas]

--- a/cli/command/rule/create.go
+++ b/cli/command/rule/create.go
@@ -31,7 +31,7 @@ func newCreateCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "create [OPTIONS] [RULE]",
 		Short: `Creates a rule. To create a rule that configures 2 replicas for volumes with the label env=prod, run:
-storageos rule create --selector env==prod --action add --label storageos.feature.replicas=2 replicator
+storageos rule create --selector env==prod --action add --label storageos.com/replicas=2 replicator
 		`,
 		Args: cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -30,7 +30,7 @@ var (
 
 // default features
 const (
-	FeatureReplicas = "storageos.feature.replicas"
+	FeatureReplicas = "storageos.com/replicas"
 )
 
 // DeviceRootPath defines the directory in which the raw StorageOS volumes are


### PR DESCRIPTION
Fixes the issue with the replica count being n/0 on `storageos volume ls`.
(Tested with node/0.10 in UE 3-node config)

Our e2e tests should have caught this.
I doubt that this output will change with much regularity so I think we should make them stricter about letting this kind of thing through. Even if the test is a little fragile against CLI changes.