### PR TITLE
formatter: remove disable sorting testcase

### DIFF
--- a/cli/command/formatter/logrus_test.go
+++ b/cli/command/formatter/logrus_test.go
@@ -40,20 +40,20 @@ func TestFormat(t *testing.T) {
 			wantResult: []byte(`time="0001-01-01T00:00:00Z" level=panic field1=val1 field2=val2
 `),
 		},
-		{
-			name: "disable sorting",
-			formatter: &TextFormatter{
-				DisableSorting: true,
-			},
-			entry: &logrus.Entry{
-				Data: map[string]interface{}{
-					"field2": "val2",
-					"field1": "val1",
-				},
-			},
-			wantResult: []byte(`time="0001-01-01T00:00:00Z" level=panic field2=val2 field1=val1
-`),
-		},
+		// 		{
+		// 			name: "disable sorting",
+		// 			formatter: &TextFormatter{
+		// 				DisableSorting: true,
+		// 			},
+		// 			entry: &logrus.Entry{
+		// 				Data: map[string]interface{}{
+		// 					"field2": "val2",
+		// 					"field1": "val1",
+		// 				},
+		// 			},
+		// 			wantResult: []byte(`time="0001-01-01T00:00:00Z" level=panic field2=val2 field1=val1
+		// `),
+		// 		},
 		{
 			name: "force colors",
 			formatter: &TextFormatter{


### PR DESCRIPTION
We have tests for sorted output. Disabled sorting results in
unpredictable map based output.

This issue was found while running tests for https://github.com/storageos/go-cli/pull/97 and https://github.com/storageos/go-cli/pull/98 .