### PR TITLE
[dev-2007] user: fix group duplication while updating user

### DIFF
--- a/cli/command/user/update.go
+++ b/cli/command/user/update.go
@@ -45,9 +45,21 @@ func (u updateOptions) processGroups(current []string) []string {
 		}
 	}
 
+	// Checks if a given group exists in the newGroups.
+	containsGroup := func(s string) bool {
+		for _, v := range newGroups {
+			if s == v {
+				return true
+			}
+		}
+		return false
+	}
+
 	// add groups
 	for _, v := range u.addGroups {
-		newGroups = append(newGroups, v)
+		if !containsGroup(v) {
+			newGroups = append(newGroups, v)
+		}
 	}
 
 	return newGroups

--- a/cli/command/user/update_test.go
+++ b/cli/command/user/update_test.go
@@ -1,0 +1,65 @@
+package user
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestProcessGroups(t *testing.T) {
+	testcases := []struct {
+		name       string
+		updateOpts updateOptions
+		current    []string
+		wantGroups []string
+	}{
+		{
+			name: "opts with groups",
+			updateOpts: updateOptions{
+				groups: stringSlice{"foo", "bar"},
+			},
+			current:    []string{"aaa", "bbb"},
+			wantGroups: []string{"foo", "bar"},
+		},
+		{
+			name: "opts with removeGroups",
+			updateOpts: updateOptions{
+				removeGroups: []string{"group2", "group3"},
+			},
+			current:    []string{"group1", "group2", "group3", "group4"},
+			wantGroups: []string{"group1", "group4"},
+		},
+		{
+			name: "opts with remove non-existing group",
+			updateOpts: updateOptions{
+				removeGroups: []string{"groupA", "groupB"},
+			},
+			current:    []string{"group1", "groupA"},
+			wantGroups: []string{"group1"},
+		},
+		{
+			name: "opts with addGroups",
+			updateOpts: updateOptions{
+				addGroups: []string{"groupA", "groupB"},
+			},
+			current:    []string{"group1", "group2"},
+			wantGroups: []string{"group1", "group2", "groupA", "groupB"},
+		},
+		{
+			name: "opts with add existing group",
+			updateOpts: updateOptions{
+				addGroups: []string{"groupA", "groupB"},
+			},
+			current:    []string{"group1", "groupA"},
+			wantGroups: []string{"group1", "groupA", "groupB"},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotGroups := tc.updateOpts.processGroups(tc.current)
+			if !reflect.DeepEqual(gotGroups, tc.wantGroups) {
+				t.Fatalf("got unexpected groups while processing groups:\n\t(GOT): %v\n\t(WNT): %v", gotGroups, tc.wantGroups)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds a check in updateOptions.processGroups() to look for an
existing group before adding a given group.