### PR TITLE
user: change verifyUpdate() signature and add tests

### DIFF
--- a/cli/command/user/update.go
+++ b/cli/command/user/update.go
@@ -13,7 +13,6 @@ import (
 
 type updateOptions struct {
 	sourceAccount string
-	username      string
 	password      bool
 	groups        stringSlice
 	addGroups     stringSlice
@@ -79,7 +78,6 @@ func newUpdateCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.StringVar(&opt.username, "username", "", "Provide a new username")
 	flags.BoolVar(&opt.password, "password", false, "Prompt for new password (interactive)")
 	flags.StringVar(&opt.role, "role", "", "Provide a new role")
 	flags.Var(&opt.groups, "groups", "Provide a new set of groups (replacing old set)")
@@ -107,10 +105,6 @@ func verifyGroupLogic(opt updateOptions) error {
 }
 
 func verifyUpdate(opt updateOptions) error {
-	if !(opt.username == "" || verifyUsername(opt.username)) {
-		return fmt.Errorf(`Username doesn't follow format "[a-zA-Z0-9]+"`)
-	}
-
 	if i, pass := verifyGroups(opt.groups); !pass {
 		return fmt.Errorf(`Group element %d doesn't follow format "[a-zA-Z0-9]+"`, i)
 	}
@@ -157,10 +151,6 @@ func runUpdate(storageosCli *command.StorageOSCli, opt updateOptions) error {
 		return fmt.Errorf("Failed to get user (%s): %s", opt.sourceAccount, err)
 	}
 	currentState.Groups = opt.processGroups(currentState.Groups)
-
-	if opt.username != "" {
-		currentState.Username = opt.username
-	}
 
 	if opt.password {
 		currentState.Password = password

--- a/cli/command/user/update.go
+++ b/cli/command/user/update.go
@@ -106,7 +106,7 @@ func verifyGroupLogic(opt updateOptions) error {
 	return nil
 }
 
-func verifyUpdate(storageosCli *command.StorageOSCli, opt updateOptions) error {
+func verifyUpdate(opt updateOptions) error {
 	if !(opt.username == "" || verifyUsername(opt.username)) {
 		return fmt.Errorf(`Username doesn't follow format "[a-zA-Z0-9]+"`)
 	}
@@ -124,7 +124,7 @@ func verifyUpdate(storageosCli *command.StorageOSCli, opt updateOptions) error {
 	}
 
 	if !(opt.role == "" || verifyRole(opt.role)) {
-		return fmt.Errorf(`Role must be either "user" or "admin", not %s`, opt.role)
+		return fmt.Errorf(`Role must be either "user" or "admin", not %q`, opt.role)
 	}
 
 	return nil
@@ -146,7 +146,7 @@ func runUpdate(storageosCli *command.StorageOSCli, opt updateOptions) error {
 		return err
 	}
 
-	if err := verifyUpdate(storageosCli, opt); err != nil {
+	if err := verifyUpdate(opt); err != nil {
 		return err
 	}
 

--- a/cli/command/user/update_test.go
+++ b/cli/command/user/update_test.go
@@ -137,25 +137,6 @@ func TestVerifyUpdate(t *testing.T) {
 		wantErr    error
 	}{
 		{
-			name: "invalid username",
-			updateOpts: updateOptions{
-				username: "%$#",
-			},
-			wantErr: errors.New(`Username doesn't follow format "[a-zA-Z0-9]+"`),
-		},
-		{
-			name: "valid username",
-			updateOpts: updateOptions{
-				username: "foo",
-			},
-		},
-		{
-			name: "empty username",
-			updateOpts: updateOptions{
-				username: "",
-			},
-		},
-		{
 			name: "invalid groups",
 			updateOpts: updateOptions{
 				groups: stringSlice{"grp1", "!@#%", "grp2"},

--- a/cli/command/user/update_test.go
+++ b/cli/command/user/update_test.go
@@ -129,3 +129,108 @@ func TestProcessGroups(t *testing.T) {
 		})
 	}
 }
+
+func TestVerifyUpdate(t *testing.T) {
+	testcases := []struct {
+		name       string
+		updateOpts updateOptions
+		wantErr    error
+	}{
+		{
+			name: "invalid username",
+			updateOpts: updateOptions{
+				username: "%$#",
+			},
+			wantErr: errors.New(`Username doesn't follow format "[a-zA-Z0-9]+"`),
+		},
+		{
+			name: "valid username",
+			updateOpts: updateOptions{
+				username: "foo",
+			},
+		},
+		{
+			name: "empty username",
+			updateOpts: updateOptions{
+				username: "",
+			},
+		},
+		{
+			name: "invalid groups",
+			updateOpts: updateOptions{
+				groups: stringSlice{"grp1", "!@#%", "grp2"},
+			},
+			wantErr: errors.New(`Group element 1 doesn't follow format "[a-zA-Z0-9]+"`),
+		},
+		{
+			name: "valid groups",
+			updateOpts: updateOptions{
+				groups: stringSlice{"grp1", "grp2"},
+			},
+		},
+		{
+			name: "invalid addGroups",
+			updateOpts: updateOptions{
+				addGroups: stringSlice{"grp1", "!@#%", "grp2"},
+			},
+			wantErr: errors.New(`add-group element 1 doesn't follow format "[a-zA-Z0-9]+"`),
+		},
+		{
+			name: "valid addGroups",
+			updateOpts: updateOptions{
+				addGroups: stringSlice{"grp1", "grp2"},
+			},
+		},
+		{
+			name: "invalid removeGroups",
+			updateOpts: updateOptions{
+				removeGroups: stringSlice{"grp1", "!@#%", "grp2"},
+			},
+			wantErr: errors.New(`remove-group element 1 doesn't follow format "[a-zA-Z0-9]+"`),
+		},
+		{
+			name: "valid removeGroups",
+			updateOpts: updateOptions{
+				removeGroups: stringSlice{"grp1", "grp2"},
+			},
+		},
+		{
+			name: "invalid role",
+			updateOpts: updateOptions{
+				role: "foo",
+			},
+			wantErr: errors.New(`Role must be either "user" or "admin", not "foo"`),
+		},
+		{
+			name: "valid role",
+			updateOpts: updateOptions{
+				role: "user",
+			},
+		},
+		{
+			name: "valid role",
+			updateOpts: updateOptions{
+				role: "admin",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifyUpdate(tc.updateOpts)
+			if err != nil {
+				if tc.wantErr != nil {
+					if err.Error() != tc.wantErr.Error() {
+						t.Errorf("unexpected error while verifying update:\n\t(GOT): %v\n\t(WNT): %v", err, tc.wantErr)
+					}
+				} else {
+					t.Errorf("unexpected error while verifying update:\n\t(GOT): %v\n\t(WNT): %v", err, tc.wantErr)
+				}
+			} else {
+				if tc.wantErr != nil {
+					t.Errorf("unexpected error while verifying update:\n\t(GOT): %v\n\t(WNT): %v", err, tc.wantErr)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change removes passing `command.StorageOSCli` argument to
verifyUpdate() because it's not used in the function.