### PR TITLE
user: check for same group in add and remove while updating

### DIFF
--- a/cli/command/user/update.go
+++ b/cli/command/user/update.go
@@ -92,6 +92,17 @@ func verifyGroupLogic(opt updateOptions) error {
 	if (len(opt.groups) > 0) && (len(opt.addGroups)+len(opt.removeGroups)) > 0 {
 		return errors.New("Cannot set both groups and add/remove groups")
 	}
+
+	// Check if a group is in both add and remove.
+	if (len(opt.addGroups) > 0) && (len(opt.removeGroups) > 0) {
+		for _, i := range opt.addGroups {
+			for _, j := range opt.removeGroups {
+				if i == j {
+					return errors.New("Cannot add and remove the same group at a time")
+				}
+			}
+		}
+	}
 	return nil
 }
 

--- a/cli/command/user/update_test.go
+++ b/cli/command/user/update_test.go
@@ -1,9 +1,75 @@
 package user
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
+
+func TestVerifyGroupLogic(t *testing.T) {
+	testcases := []struct {
+		name       string
+		updateOpts updateOptions
+		wantErr    error
+	}{
+		{
+			name: "groups only",
+			updateOpts: updateOptions{
+				groups: stringSlice{"grp1", "grp2", "grp3"},
+			},
+		},
+		{
+			name: "addGroups and removeGroups unique",
+			updateOpts: updateOptions{
+				addGroups:    stringSlice{"grp4", "grp5"},
+				removeGroups: stringSlice{"grp1", "grp2"},
+			},
+		},
+		{
+			name: "addGroups and removeGroups with duplicate",
+			updateOpts: updateOptions{
+				addGroups:    stringSlice{"grp4", "grp5"},
+				removeGroups: stringSlice{"grp5", "grp2"},
+			},
+			wantErr: errors.New("Cannot add and remove the same group at a time"),
+		},
+		{
+			name: "groups and addGroups",
+			updateOpts: updateOptions{
+				groups:    stringSlice{"grp1", "grp2", "grp3"},
+				addGroups: stringSlice{"grp4", "grp5"},
+			},
+			wantErr: errors.New("Cannot set both groups and add/remove groups"),
+		},
+		{
+			name: "groups and removeGroups",
+			updateOpts: updateOptions{
+				groups:       stringSlice{"grp1", "grp2", "grp3"},
+				removeGroups: stringSlice{"grp4", "grp5"},
+			},
+			wantErr: errors.New("Cannot set both groups and add/remove groups"),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifyGroupLogic(tc.updateOpts)
+			if err != nil {
+				if tc.wantErr != nil {
+					if err.Error() != tc.wantErr.Error() {
+						t.Errorf("unexpected error while verifying group logic:\n\t(GOT): %v\n\t(WNT): %v", err, tc.wantErr)
+					}
+				} else {
+					t.Errorf("unexpected error while verifying group logic:\n\t(GOT): %v\n\t(WNT): %v", err, tc.wantErr)
+				}
+			} else {
+				if tc.wantErr != nil {
+					t.Errorf("unexpected error while verifying group logic:\n\t(GOT): %v\n\t(WNT): %v", err, tc.wantErr)
+				}
+			}
+		})
+	}
+}
 
 func TestProcessGroups(t *testing.T) {
 	testcases := []struct {


### PR DESCRIPTION
This change adds a check to look if a group is in addGroups and
removeGroups at the same time. Also adds tests for the same.