### PR TITLE
[dev-2002] volume: show error if volume size 0 is explicitly specified

### DIFF
--- a/cli/command/volume/create.go
+++ b/cli/command/volume/create.go
@@ -79,6 +79,11 @@ func runCreate(storageosCli *command.StorageOSCli, opt createOptions) error {
 		Context:      context.Background(),
 	}
 
+	// Validate size.
+	if params.Size <= 0 {
+		return errors.New("volume size should be higher than 0")
+	}
+
 	vol, err := client.VolumeCreate(params)
 	if err != nil {
 		return err


### PR DESCRIPTION
Volume size 0 results in creating volume with default size. This change
adds a size check before posting to api endpoint.