### PR TITLE
health: Use the unified controlplane health endpoint

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -77,7 +77,7 @@
     "types",
     "types/versions"
   ]
-  revision = "7ff2d15f907ddeef0e4a4a2e2f2f4f37fc4c32a0"
+  revision = "2733cc0e17c27fbfe54daa9bdba3feb6375b0316"
 
 [[projects]]
   name = "golang.org/x/crypto"

--- a/cli/command/formatter/cluster_health.go
+++ b/cli/command/formatter/cluster_health.go
@@ -108,10 +108,9 @@ func (c *clusterHealthContext) cpHealthy() bool {
 
 func (c *clusterHealthContext) dpHealthy() bool {
 	return c.v.Health.DP.DirectFSClient.Status+
-		c.v.Health.DP.DirectFSServer.Status+
 		c.v.Health.DP.Director.Status+
 		c.v.Health.DP.FSDriver.Status+
-		c.v.Health.DP.FS.Status == "alivealivealivealivealive"
+		c.v.Health.DP.FS.Status == "alivealivealivealive"
 }
 
 func (c *clusterHealthContext) Status() string {

--- a/cli/command/formatter/node_health.go
+++ b/cli/command/formatter/node_health.go
@@ -62,6 +62,11 @@ func NodeHealthWrite(ctx Context, node *cliTypes.Node) error {
 		}
 		if node.Health.DP != nil {
 			for _, submodule := range node.Health.DP.ToNamedSubmodules() {
+				// Skip when there's not status data. This is to avoid printing
+				// empty DP fields for now.
+				if submodule.Status == "" {
+					continue
+				}
 				if err := format(&nodeHealthContext{t: "dataplane", v: submodule}); err != nil {
 					return err
 				}

--- a/cli/command/node/health.go
+++ b/cli/command/node/health.go
@@ -86,8 +86,7 @@ func UpdateNodeHealth(node *cliTypes.Node, address string, timeout int) error {
 
 	client := &http.Client{}
 
-	// CP Health Status
-	var cpStatus types.CPHealthStatus
+	var healthStatus types.HealthStatus
 	cpURL := fmt.Sprintf(healthEndpointFormat, address, api.DefaultPort)
 	cpReq, err := http.NewRequest("GET", cpURL, nil)
 	if err != nil {
@@ -99,28 +98,11 @@ func UpdateNodeHealth(node *cliTypes.Node, address string, timeout int) error {
 		return err
 	}
 
-	if err := json.NewDecoder(cpResp.Body).Decode(&cpStatus); err != nil {
+	if err := json.NewDecoder(cpResp.Body).Decode(&healthStatus); err != nil {
 		return err
 	}
-	node.Health.CP = &cpStatus
-
-	// DP Health Status
-	var dpHealth types.DPHealthStatus
-	dpURL := fmt.Sprintf(healthEndpointFormat, address, api.DataplaneHealthPort)
-	dpReq, err := http.NewRequest("GET", dpURL, nil)
-	if err != nil {
-		return err
-	}
-
-	dpResp, err := client.Do(dpReq.WithContext(ctx))
-	if err != nil {
-		return err
-	}
-
-	if err := json.NewDecoder(dpResp.Body).Decode(&dpHealth); err != nil {
-		return err
-	}
-	node.Health.DP = &dpHealth
+	node.Health.CP = healthStatus.ToCPHealthStatus()
+	node.Health.DP = healthStatus.ToDPHealthStatus()
 
 	return nil
 }

--- a/vendor/github.com/storageos/go-api/types/health.go
+++ b/vendor/github.com/storageos/go-api/types/health.go
@@ -93,3 +93,42 @@ func (d *DPHealthStatus) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+// HealthStatus is the health status json object.
+type HealthStatus struct {
+	Submodules HealthSubmodules `json:"submodules"`
+}
+
+// HealthSubmodules is the "submodules" attribuet of HealthStatus.
+type HealthSubmodules struct {
+	KV             SubModuleStatus `json:"kv,omitempty"`
+	KVWrite        SubModuleStatus `json:"kv_write,omitempty"`
+	NATS           SubModuleStatus `json:"nats,omitempty"`
+	Scheduler      SubModuleStatus `json:"scheduler,omitempty"`
+	DirectFSClient SubModuleStatus `json:"directfs_initiator,omitempty"`
+	DirectFSServer SubModuleStatus `json:"directfs_responder,omitempty"`
+	Director       SubModuleStatus `json:"director,omitempty"`
+	FSDriver       SubModuleStatus `json:"rdb,omitempty"`
+	FS             SubModuleStatus `json:"presentation,omitempty"`
+}
+
+// ToCPHealthStatus returns only CPHealthStatus from the HealthStatus.
+func (h *HealthStatus) ToCPHealthStatus() *CPHealthStatus {
+	return &CPHealthStatus{
+		KV:        h.Submodules.KV,
+		KVWrite:   h.Submodules.KVWrite,
+		NATS:      h.Submodules.KVWrite,
+		Scheduler: h.Submodules.Scheduler,
+	}
+}
+
+// ToDPHealthStatus returns only DPHealthStatus from the HealthStatus.
+func (h *HealthStatus) ToDPHealthStatus() *DPHealthStatus {
+	return &DPHealthStatus{
+		DirectFSClient: h.Submodules.DirectFSClient,
+		DirectFSServer: h.Submodules.DirectFSServer,
+		Director:       h.Submodules.Director,
+		FSDriver:       h.Submodules.FSDriver,
+		FS:             h.Submodules.FS,
+	}
+}


### PR DESCRIPTION
With this change, cli would no longer query dataplane endpoint for health
status, but use the dataplane status returned by the controlplane health
endpoint.

Depends on go-api: https://github.com/storageos/go-api/pull/41