### PR TITLE
Set user-agent with version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -77,7 +77,7 @@
     "types",
     "types/versions"
   ]
-  revision = "a9652456a395269b42bf883dd586ecadce128c19"
+  revision = "44b76c3b2b84b912bc162bac602b63095a0b25a6"
 
 [[projects]]
   name = "golang.org/x/crypto"

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -15,6 +15,7 @@ import (
 	"github.com/storageos/go-cli/cli/config/configfile"
 	cliflags "github.com/storageos/go-cli/cli/flags"
 	"github.com/storageos/go-cli/pkg/jointools"
+	"github.com/storageos/go-cli/version"
 )
 
 // Streams is an interface which exposes the standard input and output streams
@@ -158,6 +159,9 @@ func NewAPIClientFromFlags(host string, opt *cliflags.CommonOptions, configFile 
 	if err != nil {
 		return &api.Client{}, err
 	}
+
+	// Set StorageOS CLI UserAgent for all the API requests.
+	client.SetUserAgent(strings.Join([]string{version.UserAgent, version.Version}, "/"))
 
 	initClientAuth(host, opt, configFile, client)
 	return client, nil

--- a/cli/command/login/cmd.go
+++ b/cli/command/login/cmd.go
@@ -3,6 +3,7 @@ package login
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"syscall"
 
 	"github.com/dnephin/cobra"
@@ -11,6 +12,7 @@ import (
 	"github.com/storageos/go-cli/cli"
 	"github.com/storageos/go-cli/cli/command"
 	"github.com/storageos/go-cli/pkg/jointools"
+	"github.com/storageos/go-cli/version"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -59,6 +61,9 @@ func verifyCredsWithServer(username, password, host string) error {
 		return fmt.Errorf("Failed to verify credentials (%v)", err)
 	}
 	client.SetAuth(username, password)
+
+	// Set StorageOS CLI UserAgent for all the API requests.
+	client.SetUserAgent(strings.Join([]string{version.UserAgent, version.Version}, "/"))
 
 	_, err = client.Login()
 	if err != nil {

--- a/vendor/github.com/storageos/go-api/client.go
+++ b/vendor/github.com/storageos/go-api/client.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	userAgent         = "go-storageosclient"
+	DefaultUserAgent  = "go-storageosclient"
 	DefaultVersionStr = "1"
 	DefaultVersion    = 1
 )
@@ -81,6 +81,7 @@ type Client struct {
 	expectedAPIVersion     APIVersion
 	nativeHTTPClient       *http.Client
 	useTLS                 bool
+	userAgent              string
 }
 
 // ClientVersion returns the API version of the client
@@ -104,6 +105,7 @@ func NewClient(nodes string) (*Client, error) {
 		return nil, err
 	}
 	client.SkipServerVersionCheck = true
+	client.userAgent = DefaultUserAgent
 	return client, nil
 }
 
@@ -137,6 +139,11 @@ func NewVersionedClient(nodestring string, apiVersionString string) (*Client, er
 	}
 
 	return c, nil
+}
+
+// SetUserAgent sets the client useragent.
+func (c *Client) SetUserAgent(useragent string) {
+	c.userAgent = useragent
 }
 
 // SetAuth sets the API username and secret to be used for all API requests.
@@ -254,7 +261,7 @@ func (c *Client) do(method, urlpath string, doOptions doOptions) (*http.Response
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", c.userAgent)
 	if doOptions.data != nil {
 		req.Header.Set("Content-Type", "application/json")
 	} else if method == "POST" {

--- a/vendor/github.com/storageos/go-api/health.go
+++ b/vendor/github.com/storageos/go-api/health.go
@@ -23,7 +23,7 @@ func (c *Client) CPHealth(ctx context.Context, hostname string) (*types.CPHealth
 		return nil, err
 	}
 
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", c.userAgent)
 	if c.username != "" && c.secret != "" {
 		req.SetBasicAuth(c.username, c.secret)
 	}
@@ -51,7 +51,7 @@ func (c *Client) DPHealth(ctx context.Context, hostname string) (*types.DPHealth
 		return nil, err
 	}
 
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", c.userAgent)
 	if c.username != "" && c.secret != "" {
 		req.SetBasicAuth(c.username, c.secret)
 	}

--- a/version/client.go
+++ b/version/client.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	ProductName string = "storageos"
+	UserAgent   string = "storageos-cli"
 	APIVersion         = "1"
 )
 


### PR DESCRIPTION
Setting user-agent with version is needed in order to differentiate CLI
from other clients and be able to perform version compatibility for any
breaking changes.

This would require updating the go-cli version once https://github.com/storageos/go-api/pull/44 is merged.