### PR TITLE
DEV-1799: CLI output width & consistency changes

### DIFF
--- a/cli/command/cluster/health.go
+++ b/cli/command/cluster/health.go
@@ -41,7 +41,7 @@ func newHealthCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolVarP(&opt.quiet, "quiet", "q", false, "Display minimal cluster health info.  Can be used with format.")
 	flags.IntVarP(&opt.timeout, "timeout", "t", 1, "Timeout in seconds.")
-	flags.StringVar(&opt.format, "format", "", "Pretty-print health with formats: table (default), cp, dp or raw.")
+	flags.StringVar(&opt.format, "format", "", "Pretty-print health with formats: table (default), detailed, cp, dp or raw.")
 
 	return cmd
 }

--- a/cli/command/formatter/cluster_health.go
+++ b/cli/command/formatter/cluster_health.go
@@ -3,6 +3,7 @@ package formatter
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/storageos/go-cli/types"
 )
@@ -108,11 +109,42 @@ func (c *clusterHealthContext) cpHealthy() bool {
 		c.v.Health.CP.KVWrite.Status == "alivealivealive"
 }
 
+func (c *clusterHealthContext) cpDegraded() string {
+	degraded := []string{}
+	if c.v.Health.CP.KV.Status != "alive" {
+		degraded = append(degraded, clusterHealthKVHeader)
+	}
+	if c.v.Health.CP.KVWrite.Status != "alive" {
+		degraded = append(degraded, clusterHealthKVWriteHeader)
+	}
+	if c.v.Health.CP.NATS.Status != "alive" {
+		degraded = append(degraded, clusterHealthNATSHeader)
+	}
+	return "Degraded (" + strings.Join(degraded, ", ") + ")"
+}
+
 func (c *clusterHealthContext) dpHealthy() bool {
 	return c.v.Health.DP.DirectFSClient.Status+
 		c.v.Health.DP.Director.Status+
 		c.v.Health.DP.FSDriver.Status+
 		c.v.Health.DP.FS.Status == "alivealivealivealive"
+}
+
+func (c *clusterHealthContext) dpDegraded() string {
+	degraded := []string{}
+	if c.v.Health.DP.DirectFSClient.Status != "alive" {
+		degraded = append(degraded, clusterHealthDirectFSClientHeader)
+	}
+	if c.v.Health.DP.Director.Status != "alive" {
+		degraded = append(degraded, clusterHealthDirectorHeader)
+	}
+	if c.v.Health.DP.FSDriver.Status != "alive" {
+		degraded = append(degraded, clusterHealthFSDriverHeader)
+	}
+	if c.v.Health.DP.FS.Status != "alive" {
+		degraded = append(degraded, clusterHealthFSHeader)
+	}
+	return "Degraded (" + strings.Join(degraded, ", ") + ")"
 }
 
 func (c *clusterHealthContext) Status() string {
@@ -134,7 +166,7 @@ func (c *clusterHealthContext) CPStatus() string {
 	if c.cpHealthy() {
 		return "Healthy"
 	}
-	return "Not Ready"
+	return c.cpDegraded()
 }
 
 func (c *clusterHealthContext) DPStatus() string {
@@ -145,7 +177,7 @@ func (c *clusterHealthContext) DPStatus() string {
 	if c.dpHealthy() {
 		return "Healthy"
 	}
-	return "Not Ready"
+	return c.dpDegraded()
 }
 
 func (c *clusterHealthContext) NATS() string {

--- a/cli/command/formatter/cluster_health_test.go
+++ b/cli/command/formatter/cluster_health_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/storageos/go-cli/types"
 )
 
-func TestClusterHealthContextWrite(t *testing.T) {
+func TestClusterHealthWrite(t *testing.T) {
 	cases := []struct {
 		context  Context
 		expected string

--- a/cli/command/formatter/cluster_health_test.go
+++ b/cli/command/formatter/cluster_health_test.go
@@ -1,0 +1,109 @@
+package formatter
+
+import (
+	"bytes"
+	"testing"
+
+	apiTypes "github.com/storageos/go-api/types"
+	"github.com/storageos/go-cli/types"
+)
+
+func TestClusterHealthContextWrite(t *testing.T) {
+	cases := []struct {
+		context  Context
+		expected string
+	}{
+		// Quiet format
+		{
+			Context{Format: NewClusterHealthFormat(defaultClusterHealthQuietFormat, true)},
+			`Healthy
+Not Ready
+Not Ready
+`,
+		},
+		// Table format test cases
+		{
+			// Test default table format
+			Context{Format: NewClusterHealthFormat(defaultClusterHealthTableFormat, false)},
+			`NODE         ADDRESS    CP_STATUS            DP_STATUS
+storageos-1  127.0.0.1  Healthy              Healthy
+storageos-2  127.0.0.1  Degraded (KV_WRITE)  Healthy
+storageos-3  127.0.0.1  Healthy              Degraded (FS_DRIVER, FS)
+`,
+		},
+		{
+			// Test control plane table format
+			Context{Format: NewClusterHealthFormat(cpClusterHealthTableFormat, false)},
+			`NODE         ADDRESS    STATUS     KV     KV_WRITE  NATS
+storageos-1  127.0.0.1  Healthy    alive  alive     alive
+storageos-2  127.0.0.1  Not Ready  alive  unknown   alive
+storageos-3  127.0.0.1  Not Ready  alive  alive     alive
+`,
+		},
+		{
+			// Test dataplane table format
+			Context{Format: NewClusterHealthFormat(dpClusterHealthTableFormat, false)},
+			`NODE         ADDRESS    STATUS     DFS_CLIENT  DIRECTOR  FS_DRIVER  FS
+storageos-1  127.0.0.1  Healthy    alive       alive     alive      alive
+storageos-2  127.0.0.1  Not Ready  alive       alive     alive      alive
+storageos-3  127.0.0.1  Not Ready  alive       alive     unknown    unknown
+`,
+		},
+		{
+			// Test detailed table format
+			Context{Format: NewClusterHealthFormat(detailedClusterHealthTableFormat, false)},
+			`NODE         ADDRESS    STATUS     KV     NATS   DFS_CLIENT  DIRECTOR  FS_DRIVER  FS
+storageos-1  127.0.0.1  Healthy    alive  alive  alive       alive     alive      alive
+storageos-2  127.0.0.1  Not Ready  alive  alive  alive       alive     alive      alive
+storageos-3  127.0.0.1  Not Ready  alive  alive  alive       alive     unknown    unknown
+`,
+		},
+	}
+
+	aliveStatus := apiTypes.SubModuleStatus{Status: "alive"}
+	unknownStatus := apiTypes.SubModuleStatus{Status: "unknown"}
+
+	nodes := []*types.Node{
+		{Name: "storageos-1", AdvertiseAddress: "127.0.0.1",
+			Health: struct {
+				CP *apiTypes.CPHealthStatus
+				DP *apiTypes.DPHealthStatus
+			}{
+				&apiTypes.CPHealthStatus{aliveStatus, aliveStatus, aliveStatus, aliveStatus},
+				&apiTypes.DPHealthStatus{aliveStatus, aliveStatus, aliveStatus, aliveStatus, aliveStatus},
+			},
+		},
+		{Name: "storageos-2", AdvertiseAddress: "127.0.0.1",
+			Health: struct {
+				CP *apiTypes.CPHealthStatus
+				DP *apiTypes.DPHealthStatus
+			}{
+				&apiTypes.CPHealthStatus{KV: aliveStatus, KVWrite: unknownStatus, NATS: aliveStatus, Scheduler: aliveStatus},
+				&apiTypes.DPHealthStatus{aliveStatus, aliveStatus, aliveStatus, aliveStatus, aliveStatus},
+			},
+		},
+		{Name: "storageos-3", AdvertiseAddress: "127.0.0.1",
+			Health: struct {
+				CP *apiTypes.CPHealthStatus
+				DP *apiTypes.DPHealthStatus
+			}{
+				&apiTypes.CPHealthStatus{aliveStatus, aliveStatus, aliveStatus, aliveStatus},
+				&apiTypes.DPHealthStatus{DirectFSClient: aliveStatus, DirectFSServer: aliveStatus, Director: aliveStatus, FSDriver: unknownStatus, FS: unknownStatus},
+			},
+		},
+	}
+
+	for _, test := range cases {
+		output := bytes.NewBufferString("")
+		test.context.Output = output
+
+		if err := ClusterHealthWrite(test.context, nodes); err != nil {
+			t.Fatalf("unexpected error while writing cluster health context: %s", err.Error())
+		} else {
+			if test.expected != output.String() {
+				t.Errorf("unexpected result.\nexpected:\n%s\ngot:\n%s\n", test.expected, output)
+			}
+		}
+
+	}
+}

--- a/cli/command/formatter/custom.go
+++ b/cli/command/formatter/custom.go
@@ -7,7 +7,7 @@ import (
 const (
 	imageHeader        = "IMAGE"
 	createdSinceHeader = "CREATED"
-	createdAtHeader    = "CREATED AT"
+	createdAtHeader    = "CREATED_AT"
 	sizeHeader         = "SIZE"
 	labelsHeader       = "LABELS"
 	nameHeader         = "NAME"

--- a/cli/command/formatter/formatter.go
+++ b/cli/command/formatter/formatter.go
@@ -79,7 +79,7 @@ func (c *Context) postFormat(tmpl *template.Template, subContext subContext) {
 			c.header = subContext.FullHeader()
 		}
 
-		t := tabwriter.NewWriter(c.Output, 20, 1, 3, ' ', 0)
+		t := tabwriter.NewWriter(c.Output, 0, 1, 2, ' ', 0)
 		t.Write([]byte(c.header))
 		c.buffer.WriteTo(t)
 		t.Flush()

--- a/cli/command/formatter/formatter.go
+++ b/cli/command/formatter/formatter.go
@@ -16,6 +16,7 @@ const (
 	TableFormatKey         = "table"
 	RawFormatKey           = "raw"
 	PrettyFormatKey        = "pretty"
+	DetailedTableFormatKey = "detailed"
 	CPHealthTableFormatKey = "cp"
 	DPHealthTableFormatKey = "dp"
 

--- a/cli/command/formatter/node.go
+++ b/cli/command/formatter/node.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	defaultNodeQuietFormat = "{{.Name}}"
-	defaultNodeTableFormat = "table {{.Name}}\t{{.Address}}\t{{.Health}}\t{{.Scheduler}}\t{{.Volumes}}\t{{.Capacity}}\t{{.CapacityUsed}}\t{{.Version}}\t{{.Labels}}"
+	defaultNodeTableFormat = "table {{.Name}}\t{{.Address}}\t{{.Health}}\t{{.Scheduler}}\t{{.Volumes}}\t{{.Capacity}}\t{{.CapacityUsed}}\t{{.Version}}"
 
 	nodeNameHeader          = "NAME"
 	nodeAddressHeader       = "ADDRESS"

--- a/cli/command/formatter/node.go
+++ b/cli/command/formatter/node.go
@@ -23,6 +23,8 @@ const (
 	nodeCapacityUsedHeader  = "USED"
 	nodeVersionUsedHeader   = "VERSION"
 	nodeLabelHeader         = "LABEL"
+	nodeRegionHeader        = "REGION"
+	nodeFailureDomainHeader = "FAILURE_DOMAIN"
 )
 
 // NewNodeFormat returns a format for use with a node Context
@@ -154,4 +156,30 @@ func (c *nodeContext) Label(name string) string {
 		return ""
 	}
 	return c.v.Labels[name]
+}
+
+func (c *nodeContext) Region() string {
+	c.AddHeader(nodeRegionHeader)
+	if c.v.Labels == nil {
+		return ""
+	}
+
+	if val, ok := c.v.Labels["iaas/region"]; ok {
+		return val
+	}
+
+	return ""
+}
+
+func (c *nodeContext) FailureDomain() string {
+	c.AddHeader(nodeFailureDomainHeader)
+	if c.v.Labels == nil {
+		return ""
+	}
+
+	if val, ok := c.v.Labels["iaas/failure-domain"]; ok {
+		return val
+	}
+
+	return ""
 }

--- a/cli/command/formatter/node.go
+++ b/cli/command/formatter/node.go
@@ -113,7 +113,7 @@ func (c *nodeContext) Capacity() string {
 		return "-"
 	}
 
-	return units.BytesSize(float64(c.v.CapacityStats.TotalCapacityBytes))
+	return units.HumanSize(float64(c.v.CapacityStats.TotalCapacityBytes))
 }
 
 func (c *nodeContext) CapacityUsed() string {

--- a/cli/command/formatter/node.go
+++ b/cli/command/formatter/node.go
@@ -126,7 +126,7 @@ func (c *nodeContext) CapacityUsed() string {
 
 func (c *nodeContext) Version() string {
 	c.AddHeader(nodeVersionUsedHeader)
-	return fmt.Sprintf("%s (%s rev)", c.v.VersionInfo["storageos"].Version, c.v.VersionInfo["storageos"].Revision)
+	return fmt.Sprintf("%s", c.v.VersionInfo["storageos"].Version)
 }
 
 func (c *nodeContext) Labels() string {

--- a/cli/command/formatter/node_test.go
+++ b/cli/command/formatter/node_test.go
@@ -1,0 +1,118 @@
+package formatter
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/storageos/go-api/types"
+)
+
+func TestNodeWrite(t *testing.T) {
+	cases := []struct {
+		context  Context
+		expected string
+	}{
+		// Quiet format
+		{
+			Context{Format: NewNodeFormat(defaultNodeQuietFormat, true)},
+			`storageos-1
+storageos-2
+storageos-3
+`,
+		},
+		// Table format test cases
+		{
+			// Test default table format
+			Context{Format: NewNodeFormat(defaultNodeTableFormat, false)},
+			`NAME         ADDRESS    HEALTH                      SCHEDULER  VOLUMES     TOTAL  USED    VERSION
+storageos-1  127.0.0.1  Alive Less than a second    true       M: 0, R: 2  5GB    80.00%  1.0.0
+storageos-2  127.0.0.1  Alive Less than a second    false      M: 1, R: 0  5GB    52.00%  1.0.0
+storageos-3  127.0.0.1  Unknown Less than a second  false      M: 1, R: 2  5GB    60.00%  1.0.0
+`,
+		},
+	}
+
+	aliveStatus := types.SubModuleStatus{Status: "alive"}
+	unknownStatus := types.SubModuleStatus{Status: "unknown"}
+
+	nodes := []*types.Node{
+		{Name: "storageos-1",
+			CapacityStats: types.CapacityStats{
+				AvailableCapacityBytes: 1e9,
+				TotalCapacityBytes:     5e9,
+			},
+			Health:          aliveStatus.Status,
+			HealthUpdatedAt: time.Now(),
+			NodeConfig: types.NodeConfig{
+				Address: "127.0.0.1",
+			},
+			Scheduler: true,
+			VolumeStats: types.VolumeStats{
+				MasterVolumeCount:  0,
+				ReplicaVolumeCount: 2,
+			},
+			VersionInfo: map[string]types.VersionInfo{
+				"storageos": types.VersionInfo{
+					Version: "1.0.0",
+				},
+			},
+		},
+		{Name: "storageos-2",
+			CapacityStats: types.CapacityStats{
+				AvailableCapacityBytes: 2.4e9,
+				TotalCapacityBytes:     5e9,
+			},
+			Health:          aliveStatus.Status,
+			HealthUpdatedAt: time.Now(),
+			NodeConfig: types.NodeConfig{
+				Address: "127.0.0.1",
+			},
+			Scheduler: false,
+			VolumeStats: types.VolumeStats{
+				MasterVolumeCount:  1,
+				ReplicaVolumeCount: 0,
+			},
+			VersionInfo: map[string]types.VersionInfo{
+				"storageos": types.VersionInfo{
+					Version: "1.0.0",
+				},
+			},
+		},
+		{Name: "storageos-3",
+			CapacityStats: types.CapacityStats{
+				AvailableCapacityBytes: 2e9,
+				TotalCapacityBytes:     5e9,
+			},
+			Health:          unknownStatus.Status,
+			HealthUpdatedAt: time.Now(),
+			NodeConfig: types.NodeConfig{
+				Address: "127.0.0.1",
+			},
+			Scheduler: false,
+			VolumeStats: types.VolumeStats{
+				MasterVolumeCount:  1,
+				ReplicaVolumeCount: 2,
+			},
+			VersionInfo: map[string]types.VersionInfo{
+				"storageos": types.VersionInfo{
+					Version: "1.0.0",
+				},
+			},
+		},
+	}
+
+	for _, test := range cases {
+		output := bytes.NewBufferString("")
+		test.context.Output = output
+
+		if err := NodeWrite(test.context, nodes); err != nil {
+			t.Fatalf("unexpected error while writing node context: %s", err.Error())
+		} else {
+			if test.expected != output.String() {
+				t.Errorf("unexpected result.\nexpected:\n%s\ngot:\n%s\n", test.expected, output)
+			}
+		}
+
+	}
+}

--- a/cli/command/formatter/node_test.go
+++ b/cli/command/formatter/node_test.go
@@ -31,6 +31,15 @@ storageos-2  127.0.0.1  Alive Less than a second    false      M: 1, R: 0  5GB  
 storageos-3  127.0.0.1  Unknown Less than a second  false      M: 1, R: 2  5GB    60.00%  1.0.0
 `,
 		},
+		{
+			// Custom IAAS table format
+			Context{Format: NewNodeFormat("table {{.Name}}\t{{.Address}}\t{{.Health}}\t{{.CapacityUsed}}\t{{.Region}}\t{{.FailureDomain}}", false)},
+			`NAME         ADDRESS    HEALTH                      USED    REGION  FAILURE_DOMAIN
+storageos-1  127.0.0.1  Alive Less than a second    80.00%  euw     euw-1
+storageos-2  127.0.0.1  Alive Less than a second    52.00%  euw     euw-2
+storageos-3  127.0.0.1  Unknown Less than a second  60.00%  euw     euw-3
+`,
+		},
 	}
 
 	aliveStatus := types.SubModuleStatus{Status: "alive"}
@@ -46,6 +55,10 @@ storageos-3  127.0.0.1  Unknown Less than a second  false      M: 1, R: 2  5GB  
 			HealthUpdatedAt: time.Now(),
 			NodeConfig: types.NodeConfig{
 				Address: "127.0.0.1",
+				Labels: map[string]string{
+					"iaas/failure-domain": "euw-1",
+					"iaas/region":         "euw",
+				},
 			},
 			Scheduler: true,
 			VolumeStats: types.VolumeStats{
@@ -67,6 +80,10 @@ storageos-3  127.0.0.1  Unknown Less than a second  false      M: 1, R: 2  5GB  
 			HealthUpdatedAt: time.Now(),
 			NodeConfig: types.NodeConfig{
 				Address: "127.0.0.1",
+				Labels: map[string]string{
+					"iaas/failure-domain": "euw-2",
+					"iaas/region":         "euw",
+				},
 			},
 			Scheduler: false,
 			VolumeStats: types.VolumeStats{
@@ -88,6 +105,10 @@ storageos-3  127.0.0.1  Unknown Less than a second  false      M: 1, R: 2  5GB  
 			HealthUpdatedAt: time.Now(),
 			NodeConfig: types.NodeConfig{
 				Address: "127.0.0.1",
+				Labels: map[string]string{
+					"iaas/failure-domain": "euw-3",
+					"iaas/region":         "euw",
+				},
 			},
 			Scheduler: false,
 			VolumeStats: types.VolumeStats{

--- a/cli/command/formatter/node_test.go
+++ b/cli/command/formatter/node_test.go
@@ -113,6 +113,87 @@ storageos-3  127.0.0.1  Unknown Less than a second  false      M: 1, R: 2  5GB  
 				t.Errorf("unexpected result.\nexpected:\n%s\ngot:\n%s\n", test.expected, output)
 			}
 		}
+	}
+}
 
+func TestRegion(t *testing.T) {
+	cases := []struct {
+		context  nodeContext
+		expected string
+	}{
+		{
+			nodeContext{
+				HeaderContext: HeaderContext{},
+				v: types.Node{
+					NodeConfig: types.NodeConfig{
+						Labels: map[string]string{
+							"iaas/region":         "lon",
+							"iaas/failure-domain": "lon1",
+						},
+					},
+				},
+			},
+			"lon",
+		},
+		{
+			nodeContext{
+				HeaderContext: HeaderContext{},
+				v: types.Node{
+					NodeConfig: types.NodeConfig{
+						Labels: map[string]string{
+							"env": "prod",
+						},
+					},
+				},
+			},
+			"",
+		},
+	}
+
+	for _, test := range cases {
+		if region := test.context.Region(); region != test.expected {
+			t.Errorf("unexpected result.\nexpected:\n%s\ngot:\n%s\n", test.expected, region)
+		}
+	}
+}
+
+func TestFailureDomain(t *testing.T) {
+	cases := []struct {
+		context  nodeContext
+		expected string
+	}{
+		{
+			nodeContext{
+				HeaderContext: HeaderContext{},
+				v: types.Node{
+					NodeConfig: types.NodeConfig{
+						Labels: map[string]string{
+							"iaas/region":         "lon",
+							"iaas/failure-domain": "lon1",
+						},
+					},
+				},
+			},
+			"lon1",
+		},
+		{
+			nodeContext{
+				HeaderContext: HeaderContext{},
+				v: types.Node{
+					NodeConfig: types.NodeConfig{
+						Labels: map[string]string{
+							"env": "prod",
+						},
+					},
+				},
+			},
+			"",
+		},
+	}
+
+	for _, test := range cases {
+		if fd := test.context.FailureDomain(); fd != test.expected {
+			t.Errorf("unexpected result.\nexpected:\n%s\ngot:\n%s\n", test.expected, fd)
+		}
 	}
 }

--- a/cli/command/formatter/policy.go
+++ b/cli/command/formatter/policy.go
@@ -8,13 +8,13 @@ const (
 	defaultPolicyTableFormat = "table {{.ID}}\t{{.User}}\t{{.Group}}\t{{.Namespace}}"
 
 	policyIDHeader              = "ID"
-	policyUserHeader            = "User"
-	policyGroupHeader           = "Group"
-	policyReadonlyHeader        = "Readonly"
-	policyAPIGroupHeader        = "APIGroup"
-	policyResourceHeader        = "Resource"
-	policyNamespaceHeader       = "Namespace"
-	policyNonResourcePathHeader = "NonResourcePath"
+	policyUserHeader            = "USER"
+	policyGroupHeader           = "GROUP"
+	policyReadonlyHeader        = "READONLY"
+	policyAPIGroupHeader        = "API_GROUP"
+	policyResourceHeader        = "RESOURCE"
+	policyNamespaceHeader       = "NAMESPACE"
+	policyNonResourcePathHeader = "NON_RESOURCE_PATH"
 )
 
 func NewPolicyFormat(source string) Format {

--- a/cli/command/formatter/pool.go
+++ b/cli/command/formatter/pool.go
@@ -15,8 +15,8 @@ const (
 
 	poolNameHeader           = "NAME"
 	poolDefaultHeader        = "DEFAULT"
-	poolNodeSelectorHeader   = "NODE SELECTOR"
-	poolDeviceSelectorHeader = "DEVICE SELECTOR"
+	poolNodeSelectorHeader   = "NODE_SELECTOR"
+	poolDeviceSelectorHeader = "DEVICE_SELECTOR"
 	poolNodesHeader          = "NODES"
 	poolCapacityUsedHeader   = "USED"
 	poolTotalHeader          = "TOTAL"

--- a/cli/command/formatter/user.go
+++ b/cli/command/formatter/user.go
@@ -10,9 +10,9 @@ const (
 	defaultUserTableFormat = "table {{.UUID}}\t{{.Username}}\t{{.Groups}}\t{{.Role}}"
 
 	userUUIDHeader     = "ID"
-	userUsernameHeader = "Username"
-	userGroupsHeader   = "Groups"
-	userRoleHeader     = "Role"
+	userUsernameHeader = "USERNAME"
+	userGroupsHeader   = "GROUPS"
+	userRoleHeader     = "ROLE"
 )
 
 func NewUserFormat(source string, quiet bool) Format {

--- a/cli/command/formatter/volume.go
+++ b/cli/command/formatter/volume.go
@@ -15,8 +15,8 @@ const (
 	defaultVolumeTableFormat = "table {{.Name}}\t{{.Size}}\t{{.MountedBy}}\t{{.NodeSelector}}\t{{.Status}}\t{{.Replicas}}\t{{.Location}}"
 
 	volumeNameHeader         = "NAMESPACE/NAME"
-	volumeMountedByHeader    = "MOUNTED BY"
-	volumeNodeSelectorHeader = "NODE SELECTOR"
+	volumeMountedByHeader    = "MOUNTED_BY"
+	volumeNodeSelectorHeader = "NODE_SELECTOR"
 	volumeStatusHeader       = "STATUS"
 	volumeReplicasHeader     = "REPLICAS"
 	volumeLocationHeader     = "LOCATION"

--- a/cli/command/formatter/volume.go
+++ b/cli/command/formatter/volume.go
@@ -15,8 +15,8 @@ const (
 	defaultVolumeTableFormat = "table {{.Name}}\t{{.Size}}\t{{.MountedBy}}\t{{.NodeSelector}}\t{{.Status}}\t{{.Replicas}}\t{{.Location}}"
 
 	volumeNameHeader         = "NAMESPACE/NAME"
-	volumeMountedByHeader    = "MOUNTED_BY"
-	volumeNodeSelectorHeader = "NODE_SELECTOR"
+	volumeMountedByHeader    = "MOUNT"
+	volumeNodeSelectorHeader = "SELECTOR"
 	volumeStatusHeader       = "STATUS"
 	volumeReplicasHeader     = "REPLICAS"
 	volumeLocationHeader     = "LOCATION"


### PR DESCRIPTION
Changes to CLI output width and consistency. All table format headers should now be uppercase, with underscores as separators, whilst sizes should all be in the same unit.

Command specific changes:
`node ls`: Removed the revision from the version field, should be the release tag
`cluster health`: Should show only CP status and DP status by default, but when the status is degraded will show the parts which aren't healthy. `--format detailed` had been added to retain the previous output (minus the scheduler).