### PR TITLE
Revert path change in container, breaks e2e pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ RUN make build
 
 FROM alpine:3.7
 RUN apk --no-cache add ca-certificates
-COPY --from=0 /go/src/github.com/storageos/go-cli/cmd/storageos/storageos /usr/local/bin/storageos
-RUN ln -s /usr/local/bin/storageos /usr/local/bin/sos
+COPY --from=0 /go/src/github.com/storageos/go-cli/cmd/storageos/storageos /storageos
+RUN ln -s /storageos /usr/local/bin/storageos
 ENTRYPOINT ["storageos"]


### PR DESCRIPTION
The pipeline relies on having the binary at /storageos