### PR TITLE
Bugfix/dev 2326 cli only shows health of the master

### DIFF
--- a/cli/command/formatter/volume.go
+++ b/cli/command/formatter/volume.go
@@ -134,7 +134,7 @@ func (c *volumeContext) Location() string {
 			return "-"
 		}
 
-		return fmt.Sprintf("%s (%s)", master.Name, master.Health)
+		return fmt.Sprintf("%s (%s)", master.Name, c.v.Health)
 	}
 
 	return "-"

--- a/cli/command/formatter/volume.go
+++ b/cli/command/formatter/volume.go
@@ -134,7 +134,12 @@ func (c *volumeContext) Location() string {
 			return "-"
 		}
 
-		return fmt.Sprintf("%s (%s)", master.Name, c.v.Health)
+		health := c.v.Health
+		if health == "" {
+			health = "unknown"
+		}
+
+		return fmt.Sprintf("%s (%s)", master.Name, health)
 	}
 
 	return "-"

--- a/cli/command/formatter/volume_test.go
+++ b/cli/command/formatter/volume_test.go
@@ -1,0 +1,111 @@
+package formatter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/storageos/go-api/types"
+	cliconfig "github.com/storageos/go-cli/cli/config"
+)
+
+func TestVolumeWrite(t *testing.T) {
+	cases := []struct {
+		context  Context
+		expected string
+	}{
+		// Quiet format
+		{
+			Context{Format: NewVolumeFormat(defaultVolumeQuietFormat, true)},
+			`default/myVol
+production/prodVol
+chaos/unknown
+`,
+		},
+		// Table format
+		{
+			Context{Format: NewVolumeFormat(defaultVolumeTableFormat, false)},
+			`NAMESPACE/NAME      SIZE   MOUNT  SELECTOR  STATUS       REPLICAS  LOCATION
+default/myVol       100GB                   active       0/0       storageos-1 (healthy)
+production/prodVol  50GB                    active       1/1       storageos-2 (healthy)
+chaos/unknown       5GB                     unavailable  0/1       storageos-1 (unknown)
+`,
+		},
+	}
+
+	volumes := []*types.Volume{
+		{
+			Health: "healthy",
+			Master: &types.Deployment{
+				Node:     "1",
+				NodeName: "storageos-1",
+			},
+			Name:      "myVol",
+			Namespace: "default",
+			Size:      100,
+			Status:    "active",
+		},
+		{
+			Health: "healthy",
+			Labels: map[string]string{
+				cliconfig.FeatureReplicas: "1",
+			},
+			Master: &types.Deployment{
+				Node:     "2",
+				NodeName: "storageos-2",
+			},
+			Name:      "prodVol",
+			Namespace: "production",
+			Replicas: []*types.Deployment{
+				&types.Deployment{
+					Health:   "healthy",
+					Node:     "1",
+					NodeName: "storageos-1",
+					Status:   "active",
+				},
+			},
+			Size:   50,
+			Status: "active",
+		},
+		{
+			Labels: map[string]string{
+				cliconfig.FeatureReplicas: "1",
+			},
+			Master: &types.Deployment{
+				Node:     "1",
+				NodeName: "storageos-1",
+			},
+			Name:      "unknown",
+			Namespace: "chaos",
+			Size:      5,
+			Status:    "unavailable",
+		},
+	}
+
+	nodes := []*types.Node{
+		{
+			NodeConfig: types.NodeConfig{
+				ID: "1",
+			},
+			Name: "storageos-1",
+		},
+		{
+			NodeConfig: types.NodeConfig{
+				ID: "2",
+			},
+			Name: "storageos-2",
+		},
+	}
+
+	for _, test := range cases {
+		output := bytes.NewBufferString("")
+		test.context.Output = output
+
+		if err := VolumeWrite(test.context, volumes, nodes); err != nil {
+			t.Fatalf("unexpected error while writing volume context: %s", err.Error())
+		} else {
+			if test.expected != output.String() {
+				t.Errorf("unexpected result.\nexpected:\n%s\ngot:\n%s\n", test.expected, output)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Changes the CLI `volume ls` to use the health of the volume instead of the health of the master of that volume.