### PR TITLE
Preserve URI scheme of JOIN components.

### DIFF
--- a/pkg/jointools/expand.go
+++ b/pkg/jointools/expand.go
@@ -9,6 +9,7 @@ import (
 	"github.com/storageos/go-cli/discovery"
 )
 
+// ExpandJOIN will expand each JOIN fragment out to the form <scheme>://<ip>:<port>.
 func ExpandJOIN(join string) string {
 	fragments := make([]string, 0)
 
@@ -19,28 +20,34 @@ func ExpandJOIN(join string) string {
 	return strings.Join(fragments, ",")
 }
 
+// ExpandJOINFragment will, given an individal JOIN string fragment, expand it out
+// to the form <scheme>://<ip>:<port>.
 func ExpandJOINFragment(joinfragment string) []string {
 	// Check to see if this is a discovery token
 	if api.IsUUID(joinfragment) {
 		return ExpandClusterToken(joinfragment)
 	}
 
+	var scheme string
 	port := "5705"
 	switch split := strings.Split(joinfragment, "://"); len(split) {
 	case 2:
+		scheme = split[0]
 		split = split[1:len(split)]
 		fallthrough
-
 	case 1:
+		// If there was no explicit scheme, assume TCP.
+		if scheme == "" {
+			scheme = "tcp"
+		}
 		switch hostPort := strings.Split(split[0], ":"); len(hostPort) {
 		case 2:
 			port = hostPort[1]
 			fallthrough
-
 		case 1:
 			addrs := ExpandHost(hostPort[0])
 			for i, addr := range addrs {
-				addrs[i] = fmt.Sprintf("tcp://%s:%s", addr, port)
+				addrs[i] = fmt.Sprintf("%s://%s:%s", scheme, addr, port)
 			}
 			return addrs
 		}
@@ -49,6 +56,8 @@ func ExpandJOINFragment(joinfragment string) []string {
 	return nil
 }
 
+// ExpandHost will perform a lookup on the host given to it,
+// returning it's IPv4 address if successful.
 func ExpandHost(host string) []string {
 	if IsIPAddr(host) {
 		return []string{host}
@@ -70,6 +79,9 @@ func ExpandHost(host string) []string {
 	return filtered
 }
 
+// ExpandClusterToken will query the Discovery service for the cluster
+// corresponding to the token given, performing the expansion on the
+// JOIN fragments retrieved.
 func ExpandClusterToken(token string) (nodes []string) {
 	c, err := discovery.NewClient("", "", "")
 	if err != nil {

--- a/pkg/jointools/expand_test.go
+++ b/pkg/jointools/expand_test.go
@@ -18,9 +18,11 @@ func TestExpandJOINFragment(t *testing.T) {
 	}{
 		// FQDN w/wo host & port
 		{"google-public-dns-a.google.com", "tcp://8.8.8.8:5705"},
-		{"http://google-public-dns-a.google.com", "tcp://8.8.8.8:5705"},
-		{"http://google-public-dns-a.google.com:5705", "tcp://8.8.8.8:5705"},
+		{"http://google-public-dns-a.google.com", "http://8.8.8.8:5705"},
+		{"http://google-public-dns-a.google.com:5705", "http://8.8.8.8:5705"},
 		{"google-public-dns-a.google.com:5705", "tcp://8.8.8.8:5705"},
+		{"https://google-public-dns-a.google.com", "https://8.8.8.8:5705"},
+		{"https://google-public-dns-a.google.com:5705", "https://8.8.8.8:5705"},
 
 		// IP addr w/wo host & port
 		{"8.8.8.8", "tcp://8.8.8.8:5705"},
@@ -30,9 +32,11 @@ func TestExpandJOINFragment(t *testing.T) {
 
 		// local domain name w/wo host&port
 		{"localhost", "tcp://127.0.0.1:5705"},
-		{"http://localhost", "tcp://127.0.0.1:5705"},
-		{"http://localhost:5705", "tcp://127.0.0.1:5705"},
+		{"http://localhost", "http://127.0.0.1:5705"},
+		{"http://localhost:5705", "http://127.0.0.1:5705"},
 		{"localhost:5705", "tcp://127.0.0.1:5705"},
+		{"https://localhost", "https://127.0.0.1:5705"},
+		{"https://localhost:5705", "https://127.0.0.1:5705"},
 	}
 
 	for _, f := range fixtures {
@@ -58,9 +62,11 @@ func TestExpandJOINSingleHost(t *testing.T) {
 	}{
 		// FQDN w/wo host & port
 		{"google-public-dns-a.google.com", "tcp://8.8.8.8:5705"},
-		{"http://google-public-dns-a.google.com", "tcp://8.8.8.8:5705"},
-		{"http://google-public-dns-a.google.com:5705", "tcp://8.8.8.8:5705"},
+		{"http://google-public-dns-a.google.com", "http://8.8.8.8:5705"},
+		{"http://google-public-dns-a.google.com:5705", "http://8.8.8.8:5705"},
 		{"google-public-dns-a.google.com:5705", "tcp://8.8.8.8:5705"},
+		{"https://google-public-dns-a.google.com", "https://8.8.8.8:5705"},
+		{"https://google-public-dns-a.google.com:5705", "https://8.8.8.8:5705"},
 
 		// IP addr w/wo host & port
 		{"8.8.8.8", "tcp://8.8.8.8:5705"},
@@ -70,9 +76,11 @@ func TestExpandJOINSingleHost(t *testing.T) {
 
 		// local domain name w/wo host&port
 		{"localhost", "tcp://127.0.0.1:5705"},
-		{"http://localhost", "tcp://127.0.0.1:5705"},
-		{"http://localhost:5705", "tcp://127.0.0.1:5705"},
+		{"http://localhost", "http://127.0.0.1:5705"},
+		{"http://localhost:5705", "http://127.0.0.1:5705"},
 		{"localhost:5705", "tcp://127.0.0.1:5705"},
+		{"https://localhost", "https://127.0.0.1:5705"},
+		{"https://localhost:5705", "https://127.0.0.1:5705"},
 	}
 
 	for _, f := range fixtures {
@@ -103,10 +111,14 @@ func TestExpandJOINMultiHost(t *testing.T) {
 		{"google-public-dns-a.google.com,8.8.4.4", "tcp://8.8.8.8:5705,tcp://8.8.4.4:5705"},
 		{"8.8.8.8,google-public-dns-b.google.com", "tcp://8.8.8.8:5705,tcp://8.8.4.4:5705"},
 
-		{"http://google-public-dns-a.google.com:5705,http://google-public-dns-b.google.com:5705", "tcp://8.8.8.8:5705,tcp://8.8.4.4:5705"},
-		{"http://google-public-dns-a.google.com:5705,http://8.8.4.4:5705", "tcp://8.8.8.8:5705,tcp://8.8.4.4:5705"},
-		{"http://google-public-dns-a.google.com,google-public-dns-b.google.com:5705", "tcp://8.8.8.8:5705,tcp://8.8.4.4:5705"},
-		{"http://google-public-dns-a.google.com,8.8.4.4:5705", "tcp://8.8.8.8:5705,tcp://8.8.4.4:5705"},
+		{"http://google-public-dns-a.google.com:5705,http://google-public-dns-b.google.com:5705", "http://8.8.8.8:5705,http://8.8.4.4:5705"},
+		{"http://google-public-dns-a.google.com:5705,http://8.8.4.4:5705", "http://8.8.8.8:5705,http://8.8.4.4:5705"},
+		{"http://google-public-dns-a.google.com,google-public-dns-b.google.com:5705", "http://8.8.8.8:5705,tcp://8.8.4.4:5705"},
+		{"http://google-public-dns-a.google.com,8.8.4.4:5705", "http://8.8.8.8:5705,tcp://8.8.4.4:5705"},
+		{"https://google-public-dns-a.google.com:5705,https://google-public-dns-b.google.com:5705", "https://8.8.8.8:5705,https://8.8.4.4:5705"},
+		{"https://google-public-dns-a.google.com:5705,https://8.8.4.4:5705", "https://8.8.8.8:5705,https://8.8.4.4:5705"},
+		{"https://google-public-dns-a.google.com,google-public-dns-b.google.com:5705", "https://8.8.8.8:5705,tcp://8.8.4.4:5705"},
+		{"https://google-public-dns-a.google.com,8.8.4.4:5705", "https://8.8.8.8:5705,tcp://8.8.4.4:5705"},
 
 		{"google-public-dns-a.google.com,localhost", "tcp://8.8.8.8:5705,tcp://127.0.0.1:5705"},
 		{"localhost,google-public-dns-a.google.com", "tcp://127.0.0.1:5705,tcp://8.8.8.8:5705"},


### PR DESCRIPTION
HTTPS should no longer be an invalid scheme. If the URI scheme was considered a valid scheme, then it would be replaced with TCP in all instances.
I'm in favour of removing the `jointools` package - it seems like the API client should be responsible for dealing with that. But, in the meantime the behaviour should be fixed.