### PR TITLE
DEV-2477: Add default API call timeout

### DIFF
--- a/cli/command/cluster/health.go
+++ b/cli/command/cluster/health.go
@@ -14,6 +14,7 @@ import (
 	"github.com/storageos/go-cli/cli/command/formatter"
 	cliNode "github.com/storageos/go-cli/cli/command/node"
 	"github.com/storageos/go-cli/discovery"
+	"github.com/storageos/go-cli/pkg/constants"
 	cliTypes "github.com/storageos/go-cli/types"
 )
 
@@ -40,7 +41,7 @@ func newHealthCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.BoolVarP(&opt.quiet, "quiet", "q", false, "Display minimal cluster health info.  Can be used with format.")
-	flags.IntVarP(&opt.timeout, "timeout", "t", 1, "Timeout in seconds.")
+	flags.IntVarP(&opt.timeout, "timeout", "t", constants.DefaultAPITimeout, "Timeout in seconds.")
 	flags.StringVar(&opt.format, "format", "", "Pretty-print health with formats: table (default), detailed, cp, dp or raw.")
 
 	return cmd
@@ -64,7 +65,7 @@ func runHealth(storageosCli *command.StorageOSCli, opt *healthOpt) error {
 
 	sort.Sort(cliTypes.NodeByName(nodes))
 	for _, node := range nodes {
-		if err := runNodeHealth(storageosCli, node, opt.timeout); err != nil {
+		if err := runNodeHealth(node, opt.timeout); err != nil {
 			return err
 		}
 	}
@@ -76,7 +77,7 @@ func runHealth(storageosCli *command.StorageOSCli, opt *healthOpt) error {
 	return formatter.ClusterHealthWrite(clusterHealthCtx, nodes)
 }
 
-func runNodeHealth(storageosCli *command.StorageOSCli, node *cliTypes.Node, timeout int) error {
+func runNodeHealth(node *cliTypes.Node, timeout int) error {
 	addr := node.AdvertiseAddress
 
 	u, err := url.Parse(node.AdvertiseAddress)

--- a/cli/command/cluster/inspect.go
+++ b/cli/command/cluster/inspect.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+
 	"github.com/dnephin/cobra"
 	api "github.com/storageos/go-api"
 	"github.com/storageos/go-cli/cli"
@@ -35,8 +36,6 @@ func newInspectCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 }
 
 func runInspect(storageosCli *command.StorageOSCli, opt inspectOptions) error {
-	// client := storageosCli.Client()
-
 	client, err := discovery.NewClient("", "", "")
 	if err != nil {
 		return err

--- a/cli/command/logs/cmd.go
+++ b/cli/command/logs/cmd.go
@@ -4,6 +4,7 @@ import (
 	"github.com/dnephin/cobra"
 
 	"github.com/storageos/go-cli/cli/command"
+	"github.com/storageos/go-cli/pkg/constants"
 )
 
 type logOptions struct {
@@ -46,7 +47,7 @@ func NewLogsCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 	flags.StringVar(&opt.filter, "filter", "", "Set the logging filter")
 	flags.BoolVarP(&opt.clearFilter, "clear-filter", "", false, "Clears the filter")
 	flags.BoolVarP(&opt.follow, "follow", "f", false, "Tail the logs for the given node, or all nodes if not specified")
-	flags.IntVarP(&opt.timeout, "timeout", "t", 5, "Timeout in seconds.")
+	flags.IntVarP(&opt.timeout, "timeout", "t", constants.DefaultAPITimeout, "Timeout in seconds.")
 	flags.BoolVarP(&opt.quiet, "quiet", "q", false, "Only display volume names")
 	flags.StringVar(&opt.format, "format", "raw", "Output format (raw or table) or a Go template")
 

--- a/cli/command/logs/view.go
+++ b/cli/command/logs/view.go
@@ -9,6 +9,7 @@ import (
 	"github.com/storageos/go-cli/cli"
 	"github.com/storageos/go-cli/cli/command"
 	"github.com/storageos/go-cli/cli/command/formatter"
+	"github.com/storageos/go-cli/pkg/constants"
 )
 
 func newViewCommand(storageosCli *command.StorageOSCli) *cobra.Command {
@@ -27,7 +28,7 @@ func newViewCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 	flags.BoolVarP(&opt.quiet, "quiet", "q", false, "Only display log level")
 	flags.StringVar(&opt.format, "format", "", "Pretty-print config using a Go template")
 	flags.StringVarP(&opt.selector, "selector", "s", "", "Provide selector (e.g. to list all nodes with label disk=ssd' --selector=disk=ssd')")
-	flags.IntVarP(&opt.timeout, "timeout", "t", 5, "Timeout in seconds.")
+	flags.IntVarP(&opt.timeout, "timeout", "t", constants.DefaultAPITimeout, "Timeout in seconds.")
 
 	return cmd
 }

--- a/cli/command/node/health.go
+++ b/cli/command/node/health.go
@@ -14,6 +14,7 @@ import (
 	"github.com/storageos/go-cli/cli"
 	"github.com/storageos/go-cli/cli/command"
 	"github.com/storageos/go-cli/cli/command/formatter"
+	"github.com/storageos/go-cli/pkg/constants"
 	cliTypes "github.com/storageos/go-cli/types"
 )
 
@@ -40,7 +41,7 @@ func newHealthCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolVarP(&opt.quiet, "quiet", "q", false, "Display minimal node health info.  Can be used with format.")
 	flags.StringVar(&opt.format, "format", "", "Pretty-print health with formats: table (default), cp, dp or raw.")
-	flags.IntVarP(&opt.timeout, "timeout", "t", 1, "Timeout in seconds.")
+	flags.IntVarP(&opt.timeout, "timeout", "t", constants.DefaultAPITimeout, "Timeout in seconds.")
 
 	return cmd
 }

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"fmt"
 	"time"
 
 	"context"
@@ -10,6 +9,7 @@ import (
 	"github.com/storageos/go-api/types"
 	"github.com/storageos/go-cli/cli"
 	"github.com/storageos/go-cli/cli/command"
+	"github.com/storageos/go-cli/pkg/constants"
 	"github.com/storageos/go-cli/pkg/templates"
 	"github.com/storageos/go-cli/version"
 )
@@ -56,7 +56,7 @@ func NewVersionCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 }
 
 func runVersion(storageosCli *command.StorageOSCli, opts *versionOptions) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultAPITimeout*time.Second)
 	defer cancel()
 
 	templateFormat := versionTemplate
@@ -68,11 +68,6 @@ func runVersion(storageosCli *command.StorageOSCli, opts *versionOptions) error 
 	if err != nil {
 		return cli.StatusError{StatusCode: 64,
 			Status: "Template parsing error: " + err.Error()}
-	}
-
-	APIVersion := storageosCli.Client().ClientVersion()
-	if defaultAPIVersion := storageosCli.DefaultVersion(); APIVersion != defaultAPIVersion {
-		APIVersion = fmt.Sprintf("%s (downgraded from %s)", APIVersion, defaultAPIVersion)
 	}
 
 	vd := types.VersionResponse{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,6 @@
+// Package constants houses constants which are shared across packages.
+package constants
+
+// DefaultAPITimeout is the default time in seconds which an API request should be allowed
+// to run for before timing out, to account for slow network paths & bad hosts.
+const DefaultAPITimeout = 10


### PR DESCRIPTION
Use this as the default value for timeout options, as the
http client dial timeout is more lenient than it used to be.
This accounts for bad network paths, slow connections etc.