### PR TITLE
DEV-2351: Set custom discovery service endpoint

### DIFF
--- a/cli/command/cluster/create.go
+++ b/cli/command/cluster/create.go
@@ -49,7 +49,7 @@ func runCreate(storageosCli *command.StorageOSCli, opt createOptions) error {
 		return err
 	}
 
-	client, err := discovery.NewClient("", "", "")
+	client, err := discovery.NewClient(storageosCli.GetDiscovery(), "", "")
 	if err != nil {
 		return err
 	}

--- a/cli/command/cluster/health.go
+++ b/cli/command/cluster/health.go
@@ -93,14 +93,14 @@ func runNodeHealth(node *cliTypes.Node, timeout int) error {
 func getNodes(storageosCli *command.StorageOSCli, opt *healthOpt) ([]*cliTypes.Node, error) {
 
 	if opt.cluster != "" {
-		return getDiscoveryNodes(opt.cluster)
+		return getDiscoveryNodes(storageosCli.GetDiscovery(), opt.cluster)
 	}
 	return getAPINodes(storageosCli, opt.timeout)
 }
 
-func getDiscoveryNodes(clusterID string) ([]*cliTypes.Node, error) {
+func getDiscoveryNodes(discoveryHost, clusterID string) ([]*cliTypes.Node, error) {
 
-	client, err := discovery.NewClient("", "", "")
+	client, err := discovery.NewClient(discoveryHost, "", "")
 	if err != nil {
 		return nil, err
 	}

--- a/cli/command/cluster/inspect.go
+++ b/cli/command/cluster/inspect.go
@@ -36,7 +36,7 @@ func newInspectCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 }
 
 func runInspect(storageosCli *command.StorageOSCli, opt inspectOptions) error {
-	client, err := discovery.NewClient("", "", "")
+	client, err := discovery.NewClient(storageosCli.GetDiscovery(), "", "")
 	if err != nil {
 		return err
 	}

--- a/cli/command/cluster/remove.go
+++ b/cli/command/cluster/remove.go
@@ -39,7 +39,7 @@ func newRemoveCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 
 func runRemove(storageosCli *command.StorageOSCli, opt *removeOptions) error {
 
-	client, err := discovery.NewClient("", "", "")
+	client, err := discovery.NewClient(storageosCli.GetDiscovery(), "", "")
 	if err != nil {
 		return err
 	}

--- a/cli/command/login/cmd.go
+++ b/cli/command/login/cmd.go
@@ -72,7 +72,7 @@ func verifyCredsWithServer(username, password, host string) error {
 	return nil
 }
 
-func getHost(opt loginOptions, args []string) (string, error) {
+func getHost(discoveryHost string, opt loginOptions, args []string) (string, error) {
 	var join string
 
 	switch {
@@ -89,10 +89,10 @@ func getHost(opt loginOptions, args []string) (string, error) {
 		join = api.DefaultHost
 	}
 
-	if errs := jointools.VerifyJOIN(join); errs != nil {
+	if errs := jointools.VerifyJOIN(discoveryHost, join); errs != nil {
 		return "", fmt.Errorf("error: %+v", errs)
 	}
-	return jointools.ExpandJOIN(join), nil
+	return jointools.ExpandJOIN(discoveryHost, join), nil
 }
 
 func promptUsername(storageosCli *command.StorageOSCli) (string, error) {
@@ -118,7 +118,7 @@ func promptPassword(storageosCli *command.StorageOSCli) (string, error) {
 }
 
 func runLogin(storageosCli *command.StorageOSCli, opt loginOptions, args []string) (err error) {
-	opt.host, err = getHost(opt, args)
+	opt.host, err = getHost(storageosCli.GetDiscovery(), opt, args)
 	if err != nil {
 		return err
 	}

--- a/cli/command/logout/cmd.go
+++ b/cli/command/logout/cmd.go
@@ -3,6 +3,7 @@ package logout
 import (
 	"errors"
 	"fmt"
+
 	"github.com/dnephin/cobra"
 
 	api "github.com/storageos/go-api"
@@ -34,7 +35,7 @@ func NewLogoutCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 	return cmd
 }
 
-func getHost(opt logoutOptions, args []string) (string, error) {
+func getHost(discoveryHost string, opt logoutOptions, args []string) (string, error) {
 	var join string
 
 	switch {
@@ -51,15 +52,15 @@ func getHost(opt logoutOptions, args []string) (string, error) {
 		join = api.DefaultHost
 	}
 
-	if errs := jointools.VerifyJOIN(join); errs != nil {
+	if errs := jointools.VerifyJOIN(discoveryHost, join); errs != nil {
 		return "", fmt.Errorf("error: %+v", errs)
 	}
-	return jointools.ExpandJOIN(join), nil
+	return jointools.ExpandJOIN(discoveryHost, join), nil
 
 }
 
 func runDelete(storageosCli *command.StorageOSCli, opt logoutOptions, args []string) error {
-	host, err := getHost(opt, args)
+	host, err := getHost(storageosCli.GetDiscovery(), opt, args)
 	if err != nil {
 		return err
 	}

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -22,6 +22,7 @@ const (
 	EnvStorageosUsername   = "STORAGEOS_USERNAME"
 	EnvStorageosPassword   = "STORAGEOS_PASSWORD"
 	EnvStorageosAPIVersion = "STORAGEOS_API_VERSION"
+	EnvStorageOSDiscovery  = "STORAGEOS_DISCOVERY"
 )
 
 var (

--- a/cli/flags/common.go
+++ b/cli/flags/common.go
@@ -40,6 +40,7 @@ type CommonOptions struct {
 	TLSVerify  bool
 	TLSOptions *tlsconfig.Options
 	TrustKey   string
+	Discovery  string
 }
 
 // NewCommonOptions returns a new CommonOptions
@@ -56,6 +57,7 @@ func (commonOpts *CommonOptions) InstallFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&commonOpts.Debug, "debug", "D", false, "Enable debug mode")
 
 	flags.StringVarP(&commonOpts.Hosts, "host", "H", "", fmt.Sprintf("Node endpoint(s) to connect to (will override %s env variable value)", cliconfig.EnvStorageOSHost))
+	flags.StringVarP(&commonOpts.Discovery, "discovery", "d", "", fmt.Sprintf("The discovery endpoint. Defaults to https://discovery.storageos.cloud (will override %s env variable value)", cliconfig.EnvStorageOSDiscovery))
 
 	flags.StringVarP(&commonOpts.Username, "username", "u", "", fmt.Sprintf(`API username (will override %s env variable value)`, cliconfig.EnvStorageosUsername))
 	flags.StringVarP(&commonOpts.Password, "password", "p", "", fmt.Sprintf(`API password (will override %s env variable value)`, cliconfig.EnvStorageosPassword))

--- a/pkg/jointools/expand_test.go
+++ b/pkg/jointools/expand_test.go
@@ -40,7 +40,7 @@ func TestExpandJOINFragment(t *testing.T) {
 	}
 
 	for _, f := range fixtures {
-		frags := jointools.ExpandJOINFragment(f.input)
+		frags := jointools.ExpandJOINFragment("", f.input)
 		if len(frags) != 1 {
 			t.Errorf("unexpected number of endpoints (output: %+v), cluster token?", frags)
 		} else {
@@ -86,7 +86,7 @@ func TestExpandJOINSingleHost(t *testing.T) {
 	}
 
 	for _, f := range fixtures {
-		out := jointools.ExpandJOIN(f.input)
+		out := jointools.ExpandJOIN("", f.input)
 		if out != f.output {
 			t.Errorf("unexpected result. input: %v, output: %v (expected %v)", f.input, out, f.output)
 		}
@@ -129,7 +129,7 @@ func TestExpandJOINMultiHost(t *testing.T) {
 	}
 
 	for _, f := range fixtures {
-		out := jointools.ExpandJOIN(f.input)
+		out := jointools.ExpandJOIN("", f.input)
 		if out != f.output {
 			t.Errorf("unexpected result. input: %v, output: %v (expected %v)", f.input, out, f.output)
 		}

--- a/pkg/jointools/verify_test.go
+++ b/pkg/jointools/verify_test.go
@@ -51,7 +51,7 @@ func TestVerifyJOINSingleHost(t *testing.T) {
 	}
 
 	for _, f := range fixtures {
-		errs := jointools.VerifyJOIN(f.input)
+		errs := jointools.VerifyJOIN("", f.input)
 		if (errs != nil) != f.expectError {
 			t.Errorf("unexpected result. input: %v, errors: %+v (expecting error? %v)", f.input, errs, f.expectError)
 		}
@@ -90,7 +90,7 @@ func TestVerifyJOINMultiHost(t *testing.T) {
 	}
 
 	for _, f := range fixtures {
-		errs := jointools.VerifyJOIN(f.input)
+		errs := jointools.VerifyJOIN("", f.input)
 		if (errs != nil) != f.expectError {
 			t.Errorf("unexpected result. input: %v, errors: %+v (expecting error? %v)", f.input, errs, f.expectError)
 		}
@@ -141,7 +141,7 @@ func TestVerifyJOINFragment(t *testing.T) {
 	}
 
 	for _, f := range fixtures {
-		errs := jointools.VerifyJOINFragment(f.input)
+		errs := jointools.VerifyJOINFragment("", f.input)
 		if (errs != nil) != f.expectError {
 			t.Errorf("unexpected result. input: %v, errors: %+v (expecting error? %v)", f.input, errs, f.expectError)
 		}


### PR DESCRIPTION
This change adds a flag and env var support for setting discovery
service host at the root command, and is stored in StorageOSCli.
If no env var or flag is set, it uses the default discovery service.

```
$ STORAGEOS_DISCOVERY=envdiscovery storageos -d=flagdiscovery cluster create
```
In the above case, flag would override env var.