### PR TITLE
node: add node leave support

### DIFF
--- a/cli/command/node/cmd.go
+++ b/cli/command/node/cmd.go
@@ -25,6 +25,7 @@ func NewNodeCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 		newDrainCommand(storageosCli),
 		newUndrainCommand(storageosCli),
 		command.WithAlias(newUpdateCommand(storageosCli), command.UpdateAliases...),
+		command.WithAlias(newDeleteCommand(storageosCli), command.RemoveAliases...),
 	)
 	return cmd
 }

--- a/cli/command/node/delete.go
+++ b/cli/command/node/delete.go
@@ -1,0 +1,29 @@
+package node
+
+import (
+	"github.com/dnephin/cobra"
+	"github.com/storageos/go-api/types"
+	"github.com/storageos/go-cli/cli"
+	"github.com/storageos/go-cli/cli/command"
+)
+
+func newDeleteCommand(storageosCli *command.StorageOSCli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete NODE ",
+		Short: "Remove an offline node from the cluster.",
+		Args:  cli.RequiresMinArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDelete(storageosCli, args[0])
+		},
+	}
+}
+
+func runDelete(storageosCli *command.StorageOSCli, nodeID string) error {
+	client := storageosCli.Client()
+
+	opts := types.DeleteOptions{
+		Name: nodeID,
+	}
+
+	return client.NodeDelete(opts)
+}


### PR DESCRIPTION
Allows a node to be removed from the cluster if it is already offline.