### PR TITLE
DEV-2853: convert all size representation to binary (1 KiB = 1024)

### DIFF
--- a/cli/command/formatter/node.go
+++ b/cli/command/formatter/node.go
@@ -115,7 +115,7 @@ func (c *nodeContext) Capacity() string {
 		return "-"
 	}
 
-	return units.HumanSize(float64(c.v.CapacityStats.TotalCapacityBytes))
+	return bytesSize(c.v.CapacityStats.TotalCapacityBytes)
 }
 
 func (c *nodeContext) CapacityUsed() string {

--- a/cli/command/formatter/node_test.go
+++ b/cli/command/formatter/node_test.go
@@ -26,9 +26,9 @@ storageos-3
 			// Test default table format
 			Context{Format: NewNodeFormat(defaultNodeTableFormat, false)},
 			`NAME         ADDRESS    HEALTH                      SCHEDULER  VOLUMES     TOTAL  USED    VERSION
-storageos-1  127.0.0.1  Alive Less than a second    true       M: 0, R: 2  5GB    80.00%  1.0.0
-storageos-2  127.0.0.1  Alive Less than a second    false      M: 1, R: 0  5GB    52.00%  1.0.0
-storageos-3  127.0.0.1  Unknown Less than a second  false      M: 1, R: 2  5GB    60.00%  1.0.0
+storageos-1  127.0.0.1  Alive Less than a second    true       M: 0, R: 2  5GiB   80.00%  1.0.0
+storageos-2  127.0.0.1  Alive Less than a second    false      M: 1, R: 0  5GiB   52.00%  1.0.0
+storageos-3  127.0.0.1  Unknown Less than a second  false      M: 1, R: 2  5GiB   60.00%  1.0.0
 `,
 		},
 		{
@@ -48,8 +48,8 @@ storageos-3  127.0.0.1  Unknown Less than a second  60.00%  euw     euw-3
 	nodes := []*types.Node{
 		{Name: "storageos-1",
 			CapacityStats: types.CapacityStats{
-				AvailableCapacityBytes: 1e9,
-				TotalCapacityBytes:     5e9,
+				AvailableCapacityBytes: 1 * GiB,
+				TotalCapacityBytes:     5 * GiB,
 			},
 			Health:          aliveStatus.Status,
 			HealthUpdatedAt: time.Now(),
@@ -73,8 +73,8 @@ storageos-3  127.0.0.1  Unknown Less than a second  60.00%  euw     euw-3
 		},
 		{Name: "storageos-2",
 			CapacityStats: types.CapacityStats{
-				AvailableCapacityBytes: 2.4e9,
-				TotalCapacityBytes:     5e9,
+				AvailableCapacityBytes: GiB * 12 / 5, // 2.4
+				TotalCapacityBytes:     5 * GiB,
 			},
 			Health:          aliveStatus.Status,
 			HealthUpdatedAt: time.Now(),
@@ -98,8 +98,8 @@ storageos-3  127.0.0.1  Unknown Less than a second  60.00%  euw     euw-3
 		},
 		{Name: "storageos-3",
 			CapacityStats: types.CapacityStats{
-				AvailableCapacityBytes: 2e9,
-				TotalCapacityBytes:     5e9,
+				AvailableCapacityBytes: 2 * GiB,
+				TotalCapacityBytes:     5 * GiB,
 			},
 			Health:          unknownStatus.Status,
 			HealthUpdatedAt: time.Now(),

--- a/cli/command/formatter/pool.go
+++ b/cli/command/formatter/pool.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"strings"
 
-	units "github.com/docker/go-units"
 	"github.com/storageos/go-api/types"
 )
 
@@ -96,7 +95,7 @@ func (c *poolContext) CapacityUsed() string {
 
 func (c *poolContext) Total() string {
 	c.AddHeader(poolTotalHeader)
-	return units.HumanSize(float64(c.v.CapacityStats.TotalCapacityBytes))
+	return bytesSize(c.v.CapacityStats.TotalCapacityBytes)
 }
 
 func (c *poolContext) Labels() string {

--- a/cli/command/formatter/util.go
+++ b/cli/command/formatter/util.go
@@ -4,7 +4,12 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/docker/go-units"
 )
+
+// GiB is 1024 * 1024 * 1024
+const GiB = 1024 * 1024 * 1024
 
 func writeLabels(labels map[string]string) string {
 	var joinLabels []string
@@ -19,4 +24,13 @@ func writeLabels(labels map[string]string) string {
 	})
 
 	return strings.Join(joinLabels, ",")
+}
+
+// bytesSize returns a human-readable size in bytes, kibibytes,
+// mebibytes, gibibytes, or tebibytes (eg. "44kiB", "17MiB").
+// Ref: https://en.wikipedia.org/wiki/Binary_prefix.
+//
+// it should be used by all size display including pool, node and volume
+func bytesSize(size uint64) string {
+	return units.BytesSize(float64(size))
 }

--- a/cli/command/formatter/volume.go
+++ b/cli/command/formatter/volume.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"strings"
 
-	units "github.com/docker/go-units"
 	"github.com/storageos/go-api/types"
 	cliconfig "github.com/storageos/go-cli/cli/config"
 )
@@ -108,7 +107,7 @@ func (c *volumeContext) NodeSelector() string {
 
 func (c *volumeContext) Size() string {
 	c.AddHeader(sizeHeader)
-	return units.HumanSize(float64(c.v.Size * 1000000000))
+	return bytesSize(uint64(c.v.Size) * GiB)
 }
 
 func (c *volumeContext) Status() string {

--- a/cli/command/formatter/volume_test.go
+++ b/cli/command/formatter/volume_test.go
@@ -24,10 +24,10 @@ chaos/unknown
 		// Table format
 		{
 			Context{Format: NewVolumeFormat(defaultVolumeTableFormat, false)},
-			`NAMESPACE/NAME      SIZE   MOUNT  SELECTOR  STATUS       REPLICAS  LOCATION
-default/myVol       100GB                   active       0/0       storageos-1 (healthy)
-production/prodVol  50GB                    active       1/1       storageos-2 (healthy)
-chaos/unknown       5GB                     unavailable  0/1       storageos-1 (unknown)
+			`NAMESPACE/NAME      SIZE    MOUNT  SELECTOR  STATUS       REPLICAS  LOCATION
+default/myVol       100GiB                   active       0/0       storageos-1 (healthy)
+production/prodVol  50GiB                    active       1/1       storageos-2 (healthy)
+chaos/unknown       5GiB                     unavailable  0/1       storageos-1 (unknown)
 `,
 		},
 	}


### PR DESCRIPTION
Fix size inconsistency by converting all size representation from decimal to binary (1 KiB = 1024).

Ref: https://en.wikipedia.org/wiki/Binary_prefix
