### PR TITLE
Disable cluster health

### DIFF
--- a/cli/command/cluster/cmd.go
+++ b/cli/command/cluster/cmd.go
@@ -19,7 +19,8 @@ func NewClusterCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 		command.WithAlias(newCreateCommand(storageosCli), command.CreateAliases...),
 		command.WithAlias(newInspectCommand(storageosCli), command.InspectAliases...),
 		command.WithAlias(newRemoveCommand(storageosCli), command.RemoveAliases...),
-		command.WithAlias(newHealthCommand(storageosCli), command.HealthAliases...),
+		// TODO: re-enable after GA, with the required API changes
+		//command.WithAlias(newHealthCommand(storageosCli), command.HealthAliases...),
 		newConnectivityCommand(storageosCli),
 	)
 	return cmd


### PR DESCRIPTION
This feature does not work correctly behind load balancers or in k8s.
A fix would require API changes.
Disabling this feature temporarily to avoid holding up a release.

This change should be automatically reflected in the bash completion.

(UPDATE: I have tested this, the bash completion is generated correctly)