### PR TITLE
remove the debugging logic accidentally introduced

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -84,7 +84,6 @@ func (cli *StorageOSCli) DefaultVersion() string {
 
 // Client returns the APIClient
 func (cli *StorageOSCli) Client() *api.Client {
-	cli.client.SkipServerVersionCheck = true
 	return cli.client
 }
 


### PR DESCRIPTION
remove the debugging logic accidentally introduced by the maintenance API PR.