### PR TITLE
DEV-2865: support maintenance mode management (resubmit with CI e2e test)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -141,7 +141,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e8f3dfac9c54ab338722096fdbb359eddf014e6f3497fff0d8189c55bccc809a"
+  digest = "1:dc1a5c9244d323ed265f0cb20cccaadbbff15716644aa66d31cacf9ad7b5f414"
   name = "github.com/storageos/go-api"
   packages = [
     ".",
@@ -151,7 +151,7 @@
     "types/versions",
   ]
   pruneopts = "UT"
-  revision = "f9288ce3a5ddb88a24b513fbe48477dfa019debd"
+  revision = "29374b2dad94dc28efed1bfda49e094069641e9e"
 
 [[projects]]
   digest = "1:f18cfce8b0cb8923d70a9050b211197629cb7e27efea064b4d6d3ee472d1243e"

--- a/cli/command/cluster/cmd.go
+++ b/cli/command/cluster/cmd.go
@@ -22,6 +22,7 @@ func NewClusterCommand(storageosCli *command.StorageOSCli) *cobra.Command {
 		// TODO: re-enable after GA, with the required API changes
 		//command.WithAlias(newHealthCommand(storageosCli), command.HealthAliases...),
 		newConnectivityCommand(storageosCli),
+		newMaintenanceCommand(storageosCli),
 	)
 	return cmd
 }

--- a/cli/command/cluster/maintenance.go
+++ b/cli/command/cluster/maintenance.go
@@ -1,0 +1,60 @@
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/dnephin/cobra"
+
+	"github.com/storageos/go-cli/cli"
+	"github.com/storageos/go-cli/cli/command"
+	"github.com/storageos/go-cli/cli/command/inspect"
+)
+
+type maintenanceOptions struct {
+	format string
+}
+
+func newMaintenanceCommand(storageosCli *command.StorageOSCli) *cobra.Command {
+	var opt maintenanceOptions
+
+	cmd := &cobra.Command{
+		Use:   "maintenance [OPTIONS] enable|disable|inspect",
+		Short: "Enable|disable maintenance mode for the cluster",
+		Args:  cli.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch args[0] {
+			case "inspect":
+				return getMaintenance(storageosCli, opt)
+			case "enable":
+				return enableMaintenance(storageosCli, opt)
+			case "disable":
+				return disableMaintenance(storageosCli, opt)
+			default:
+				return fmt.Errorf("wrong argument %s", args[0])
+			}
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opt.format, "format", "f", "", "Format the output using the given Go template.")
+	return cmd
+}
+
+func getMaintenance(storageosCli *command.StorageOSCli, opt maintenanceOptions) error {
+	client := storageosCli.Client()
+
+	getFunc := func(string) (interface{}, []byte, error) {
+		i, err := client.Maintenance()
+		return i, nil, err
+	}
+
+	return inspect.Inspect(storageosCli.Out(), []string{""}, opt.format, getFunc)
+}
+
+func enableMaintenance(storageosCli *command.StorageOSCli, opt maintenanceOptions) error {
+	return storageosCli.Client().EnableMaintenance()
+}
+
+func disableMaintenance(storageosCli *command.StorageOSCli, opt maintenanceOptions) error {
+	return storageosCli.Client().DisableMaintenance()
+}

--- a/vendor/github.com/storageos/go-api/cluster.go
+++ b/vendor/github.com/storageos/go-api/cluster.go
@@ -1,0 +1,48 @@
+package storageos
+
+import (
+	"encoding/json"
+
+	"github.com/storageos/go-api/types"
+)
+
+var (
+	// ClusterMaintenanceAPIPrefix is a path to the HTTP endpoint for managing
+	// the cluster maintenance mode.
+	ClusterMaintenanceAPIPrefix = "cluster/maintenance"
+)
+
+// Maintenance returns the maintenance status of the cluster
+func (c *Client) Maintenance() (*types.Maintenance, error) {
+	resp, err := c.do("GET", ClusterMaintenanceAPIPrefix, doOptions{})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	res := &types.Maintenance{}
+	if err := json.NewDecoder(resp.Body).Decode(res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// EnableMaintenance enables maintenance mode in the cluster
+func (c *Client) EnableMaintenance() error {
+	resp, err := c.do("POST", ClusterMaintenanceAPIPrefix, doOptions{})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+// DisableMaintenance disables maintenance mode in the cluster
+func (c *Client) DisableMaintenance() error {
+	resp, err := c.do("DELETE", ClusterMaintenanceAPIPrefix, doOptions{})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}

--- a/vendor/github.com/storageos/go-api/types/cluster.go
+++ b/vendor/github.com/storageos/go-api/types/cluster.go
@@ -1,0 +1,10 @@
+package types
+
+import "time"
+
+// Maintenance is used to place the cluster in maintenance mode.
+type Maintenance struct {
+	Enabled   bool      `json:"enabled"`
+	UpdatedBy string    `json:"updatedBy"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}


### PR DESCRIPTION
Support `storageos cluster maintenance [enable|disable|inspect]`.

See in the ticket for the CI link.

Original PR here:
https://github.com/storageos/go-cli/pull/162