### PR TITLE
Bugfix/dev 3256 cli format not behaving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+.vscode

--- a/cli/command/formatter/util.go
+++ b/cli/command/formatter/util.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/docker/go-units"
 	"github.com/storageos/go-cli/cli/command/inspect"
 	"github.com/storageos/go-cli/pkg/templates"
@@ -63,7 +65,9 @@ func TryFormatSpec(format string, in interface{}) {
 		os.Exit(1)
 	}
 
-	printer.Inspect(in, nil)
+	if err := printer.Inspect(in, nil); err != nil {
+		logrus.WithError(err).Debug("template error")
+	}
 	printer.Flush()
 	os.Exit(0)
 }

--- a/cli/command/formatter/volume.go
+++ b/cli/command/formatter/volume.go
@@ -43,7 +43,7 @@ func VolumeWrite(ctx Context, volumes []*types.Volume, nodes []*types.Node) erro
 	// Try handle a custom format, excluding the predefined templates
 	TryFormatUnless(
 		string(ctx.Format),
-		nodes,
+		volumes,
 		defaultVolumeQuietFormat,
 		defaultVolumeTableFormat,
 		`name: {{.Name}}`,

--- a/pkg/templates/help_text.go
+++ b/pkg/templates/help_text.go
@@ -2,7 +2,6 @@ package templates
 
 import (
 	"bytes"
-	"strings"
 	"text/template"
 )
 
@@ -81,22 +80,12 @@ func HelpText(in interface{}) string {
 		Description string
 	}
 
-	trimInitialSlice := func(ss []string) []string {
-		prefix := "{{ .[]"
-		for i, s := range ss {
-			if strings.HasPrefix(s, prefix) {
-				ss[i] = "{{ " + strings.TrimPrefix(s, prefix)
-			}
-		}
-		return ss
-	}
-
 	// Define all the available functions, and some usage info
 	data := struct {
 		Fields    []string
 		Functions []Func
 	}{
-		Fields: trimInitialSlice(DescribeFields(in)),
+		Fields: DescribeFields(in),
 		Functions: []Func{
 			{
 				Name:        "json",

--- a/pkg/templates/help_text.go
+++ b/pkg/templates/help_text.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"bytes"
+	"strings"
 	"text/template"
 )
 
@@ -80,17 +81,32 @@ func HelpText(in interface{}) string {
 		Description string
 	}
 
+	trimInitialSlice := func(ss []string) []string {
+		prefix := "{{ .[]"
+		for i, s := range ss {
+			if strings.HasPrefix(s, prefix) {
+				ss[i] = "{{ " + strings.TrimPrefix(s, prefix)
+			}
+		}
+		return ss
+	}
+
 	// Define all the available functions, and some usage info
 	data := struct {
 		Fields    []string
 		Functions []Func
 	}{
-		Fields: DescribeFields(in),
+		Fields: trimInitialSlice(DescribeFields(in)),
 		Functions: []Func{
 			{
 				Name:        "json",
 				Args:        ".Field",
 				Description: "JSON encode .Field",
+			},
+			{
+				Name:        "prettyjson",
+				Args:        ".Field",
+				Description: "JSON encode .Field, with whitespace indentation",
 			},
 			{
 				Name:        "split",

--- a/pkg/templates/template_fields.go
+++ b/pkg/templates/template_fields.go
@@ -126,9 +126,11 @@ func walkSlice(in reflect.Value, parent *field) []field {
 	v = deref(v)
 
 	// If a slice is passed directly to walkFields, parent will be nil
+	// In this case we dont want to show the [] as the formatter will be called
+	// recursively with each element (how docker's cli behaves)
 	if parent == nil {
 		return walkFields(v, &field{
-			Path: []string{"[]"},
+			Path: []string{},
 		})
 	}
 

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -2,6 +2,8 @@ package templates
 
 import (
 	"encoding/json"
+	"fmt"
+	"reflect"
 	"strings"
 	"text/template"
 )
@@ -17,13 +19,48 @@ var basicFunctions = template.FuncMap{
 		}
 		return string(a)
 	},
+	"prettyjson": func(v interface{}) string {
+		a, err := json.MarshalIndent(v, "", "\t")
+		if err != nil {
+			return "<unable to JSON encode this field>"
+		}
+		return string(a)
+	},
 	"split":    strings.Split,
-	"join":     strings.Join,
+	"join":     joinWrap,
 	"title":    strings.Title,
 	"lower":    strings.ToLower,
 	"upper":    strings.ToUpper,
-	"pad":      padWithSpace,
+	"pad":      padWith,
 	"truncate": truncateWithLength,
+}
+
+// joinWrap makes a best attempt to pass arbitrary data to the strings.Join method
+// this is needed as the templating system passes in slices of arbitrary data types
+// to this method, causing it to fail in the case of anything other than a slice of
+// strings.
+//
+// We try to reflectively iterate over the provided type and pass each element to a
+// fmt.Sprint call. We use this method to build a slice of string types, then pass
+// this to the originally intended strings.Join method.
+func joinWrap(unknown interface{}, joinChar string) string {
+	if reflect.TypeOf(unknown).Kind() == reflect.Slice {
+		val := reflect.ValueOf(unknown)
+		len := val.Len()
+
+		formatted := []string{}
+		for i := 0; i < len; i++ {
+			asInterface := val.Index(i).Interface()
+
+			// Assume fmt has the best chance of formatting the type
+			formatted = append(formatted, fmt.Sprint(asInterface))
+
+		}
+		return strings.Join(formatted, joinChar)
+
+	}
+	return "<unable to process slice>"
+
 }
 
 // Parse creates a new anonymous template with the basic functions
@@ -38,12 +75,12 @@ func NewParse(tag, format string) (*template.Template, error) {
 	return template.New(tag).Funcs(basicFunctions).Parse(format)
 }
 
-// padWithSpace adds whitespace to the input if the input is non-empty
-func padWithSpace(source string, prefix, suffix int) string {
+// padWith adds whitespace to the input if the input is non-empty
+func padWith(source, padchar string, prefix, suffix int) string {
 	if source == "" {
 		return source
 	}
-	return strings.Repeat(" ", prefix) + source + strings.Repeat(" ", suffix)
+	return strings.Repeat(padchar, prefix) + source + strings.Repeat(padchar, suffix)
 }
 
 // truncateWithLength truncates the source string up to the length provided by the input


### PR DESCRIPTION
Fixes the issue of blank strings being provided when valid `--format` options were provided
Also fixes issue that `volume --format` was returning node fields

As this wasn't the nicest thing to debug in it's absence, I also added debug logging for template execution errors. Before the CLI would silently eat this error even in debug mode.