### PR TITLE
Fix table based formatting

### DIFF
--- a/cli/command/formatter/cluster_health.go
+++ b/cli/command/formatter/cluster_health.go
@@ -61,18 +61,19 @@ func NewClusterHealthFormat(source string, quiet bool) Format {
 
 // ClusterHealthWrite writes formatted ClusterHealthhelements using the Context
 func ClusterHealthWrite(ctx Context, status []*apiTypes.ClusterHealthNode) error {
-	TryFormatUnless(
+	TryFormatUnlessMatches(
 		string(ctx.Format),
 		status,
-		defaultClusterHealthQuietFormat,
-		defaultClusterHealthTableFormat,
-		detailedClusterHealthTableFormat,
-		cpClusterHealthTableFormat,
-		dpClusterHealthTableFormat,
-		`{{.CPStatus}}`,
-		`{{.DPStatus}}`,
-		`{{.Node}}: {{.Status}}`,
-		`node: {{.Node}}\nstatus: {{.Status}}\nkv: {{.KV}}\nkv_write: {{.KVWrite}}\nnats: {{.NATS}}\ndfs_client: {{.DirectFSClient}}\ndirector: {{.Director}}\nfs_driver: {{.FSDriver}}\nfs: {{.FS}}\n`,
+		TableMatcher,
+		NewExactMatcher(defaultClusterHealthQuietFormat),
+		NewExactMatcher(defaultClusterHealthTableFormat),
+		NewExactMatcher(detailedClusterHealthTableFormat),
+		NewExactMatcher(cpClusterHealthTableFormat),
+		NewExactMatcher(dpClusterHealthTableFormat),
+		NewExactMatcher(`{{.CPStatus}}`),
+		NewExactMatcher(`{{.DPStatus}}`),
+		NewExactMatcher(`{{.Node}}: {{.Status}}`),
+		NewExactMatcher(`node: {{.Node}}\nstatus: {{.Status}}\nkv: {{.KV}}\nkv_write: {{.KVWrite}}\nnats: {{.NATS}}\ndfs_client: {{.DirectFSClient}}\ndirector: {{.Director}}\nfs_driver: {{.FSDriver}}\nfs: {{.FS}}\n`),
 	)
 
 	if len(status) == 0 {

--- a/cli/command/formatter/connectivity.go
+++ b/cli/command/formatter/connectivity.go
@@ -44,14 +44,15 @@ func NewConnectivityFormat(source string, quiet bool) Format {
 // ConnectivityWrite writes formatted connectivity results using the Context
 func ConnectivityWrite(ctx Context, results types.ConnectivityResults) error {
 	// Try handle a custom format, excluding the predefined templates
-	TryFormatUnless(
+	TryFormatUnlessMatches(
 		string(ctx.Format),
 		results,
-		connectivityTableFormat,
-		connectivityTableQuietFormat,
-		connectivityRawFormat,
-		connectivityRawQuietFormat,
-		connectivitySummaryFormat,
+		TableMatcher,
+		NewExactMatcher(connectivityTableFormat),
+		NewExactMatcher(connectivityTableQuietFormat),
+		NewExactMatcher(connectivityRawFormat),
+		NewExactMatcher(connectivityRawQuietFormat),
+		NewExactMatcher(connectivitySummaryFormat),
 	)
 
 	render := func(format func(subContext subContext) error) error {

--- a/cli/command/formatter/namespace.go
+++ b/cli/command/formatter/namespace.go
@@ -35,13 +35,14 @@ func NewNamespaceFormat(source string, quiet bool) Format {
 // NamespaceWrite writes formatted namespaces using the Context
 func NamespaceWrite(ctx Context, namespaces []*types.Namespace) error {
 	// Try handle a custom format, excluding the predefined templates
-	TryFormatUnless(
+	TryFormatUnlessMatches(
 		string(ctx.Format),
 		namespaces,
-		defaultNamespaceQuietFormat,
-		defaultNamespaceTableFormat,
-		`name: {{.Name}}`,
-		`name: {{.Name}}\ndisplay name: {{.DisplayName}}\n`,
+		TableMatcher,
+		NewExactMatcher(defaultNamespaceQuietFormat),
+		NewExactMatcher(defaultNamespaceTableFormat),
+		NewExactMatcher(`name: {{.Name}}`),
+		NewExactMatcher(`name: {{.Name}}\ndisplay name: {{.DisplayName}}\n`),
 	)
 
 	render := func(format func(subContext subContext) error) error {

--- a/cli/command/formatter/node.go
+++ b/cli/command/formatter/node.go
@@ -47,13 +47,14 @@ func NewNodeFormat(source string, quiet bool) Format {
 // NodeWrite writes formatted nodes using the Context
 func NodeWrite(ctx Context, nodes []*types.Node) error {
 	// Try handle a custom format, excluding the predefined templates
-	TryFormatUnless(
+	TryFormatUnlessMatches(
 		string(ctx.Format),
 		nodes,
-		defaultNodeQuietFormat,
-		defaultNodeTableFormat,
-		`name: {{.Name}}`,
-		`name: {{.Name}}\naddress: {{.Address}}\nhealth: {{.Health}}\nscheduler: {{.Scheduler}}\nvolumes: {{.Volumes}}\ncapacity: {{.Capacity}}\ncapacityUsed: {{.CapacityUsed}}\nversion: {{.Version}}\nlabels: {{.Labels}}\n`,
+		TableMatcher,
+		NewExactMatcher(defaultNodeQuietFormat),
+		NewExactMatcher(defaultNodeTableFormat),
+		NewExactMatcher(`name: {{.Name}}`),
+		NewExactMatcher(`name: {{.Name}}\naddress: {{.Address}}\nhealth: {{.Health}}\nscheduler: {{.Scheduler}}\nvolumes: {{.Volumes}}\ncapacity: {{.Capacity}}\ncapacityUsed: {{.CapacityUsed}}\nversion: {{.Version}}\nlabels: {{.Labels}}\n`),
 	)
 
 	render := func(format func(subContext subContext) error) error {

--- a/cli/command/formatter/node_health.go
+++ b/cli/command/formatter/node_health.go
@@ -53,16 +53,17 @@ func NewNodeHealthFormat(source string, quiet bool) Format {
 // NodeHealthWrite writes formatted NamedSubModuleStatus elements using the Context
 func NodeHealthWrite(ctx Context, node *cliTypes.Node) error {
 	// Try handle a custom format, excluding the predefined templates
-	TryFormatUnless(
+	TryFormatUnlessMatches(
 		string(ctx.Format),
 		node,
-		defaultNodeSubmodulesQuietFormat,
-		defaultNodeSubmodulesTableFormat,
-		cpNodeSubmodulesTableFormat,
-		dpNodeSubmodulesTableFormat,
-		cpNodeSubmodulesQuietFormat,
-		dpNodeSubmodulesQuietFormat,
-		defaultNodeRawFormat,
+		TableMatcher,
+		NewExactMatcher(defaultNodeSubmodulesQuietFormat),
+		NewExactMatcher(defaultNodeSubmodulesTableFormat),
+		NewExactMatcher(cpNodeSubmodulesTableFormat),
+		NewExactMatcher(dpNodeSubmodulesTableFormat),
+		NewExactMatcher(cpNodeSubmodulesQuietFormat),
+		NewExactMatcher(dpNodeSubmodulesQuietFormat),
+		NewExactMatcher(defaultNodeRawFormat),
 	)
 
 	render := func(format func(subContext subContext) error) error {

--- a/cli/command/formatter/policy.go
+++ b/cli/command/formatter/policy.go
@@ -38,12 +38,13 @@ func NewPolicyFormat(source string, quiet bool) Format {
 // using the format specified within the context.
 func PolicyWrite(ctx Context, policies []*types.PolicyWithID) error {
 	// Try handle a custom format, excluding the predefined templates
-	TryFormatUnless(
+	TryFormatUnlessMatches(
 		string(ctx.Format),
 		policies,
-		defaultPolicyTableFormat,
-		defaultPolicyQuietFormat,
-		"name: {{.Name}}\nuser: {{.User}}\ngroup: {{.Group}}\nnamespace: {{.Namespace}}",
+		TableMatcher,
+		NewExactMatcher(defaultPolicyTableFormat),
+		NewExactMatcher(defaultPolicyQuietFormat),
+		NewExactMatcher("name: {{.Name}}\nuser: {{.User}}\ngroup: {{.Group}}\nnamespace: {{.Namespace}}"),
 	)
 
 	render := func(format func(subContext subContext) error) error {

--- a/cli/command/formatter/pool.go
+++ b/cli/command/formatter/pool.go
@@ -41,13 +41,14 @@ func NewPoolFormat(source string, quiet bool) Format {
 // PoolWrite writes formatted pools using the Context
 func PoolWrite(ctx Context, pools []*types.Pool) error {
 	// Try handle a custom format, excluding the predefined templates
-	TryFormatUnless(
+	TryFormatUnlessMatches(
 		string(ctx.Format),
 		pools,
-		defaultPoolQuietFormat,
-		defaultPoolTableFormat,
-		`name: {{.Name}}`,
-		`name: {{.Name}}\n node selector: {{.NodeSelector}}\n`,
+		TableMatcher,
+		NewExactMatcher(defaultPoolQuietFormat),
+		NewExactMatcher(defaultPoolTableFormat),
+		NewExactMatcher(`name: {{.Name}}`),
+		NewExactMatcher(`name: {{.Name}}\n node selector: {{.NodeSelector}}\n`),
 	)
 
 	render := func(format func(subContext subContext) error) error {

--- a/cli/command/formatter/rule.go
+++ b/cli/command/formatter/rule.go
@@ -39,13 +39,14 @@ func NewRuleFormat(source string, quiet bool) Format {
 // RuleWrite writes formatted rules using the Context
 func RuleWrite(ctx Context, rules []*types.Rule) error {
 	// Try handle a custom format, excluding the predefined templates
-	TryFormatUnless(
+	TryFormatUnlessMatches(
 		string(ctx.Format),
 		rules,
-		defaultRuleQuietFormat,
-		defaultRuleTableFormat,
-		`name: {{.Name}}`,
-		`name: {{.Name}}\nselector: {{.Selector}}\noperator: {{.Operator}}\naction: {{.RuleAction}}\nlabels: {{.Labels}}\n`,
+		TableMatcher,
+		NewExactMatcher(defaultRuleQuietFormat),
+		NewExactMatcher(defaultRuleTableFormat),
+		NewExactMatcher(`name: {{.Name}}`),
+		NewExactMatcher(`name: {{.Name}}\nselector: {{.Selector}}\noperator: {{.Operator}}\naction: {{.RuleAction}}\nlabels: {{.Labels}}\n`),
 	)
 
 	render := func(format func(subContext subContext) error) error {

--- a/cli/command/formatter/user.go
+++ b/cli/command/formatter/user.go
@@ -40,13 +40,14 @@ func NewUserFormat(source string, quiet bool) Format {
 // using the format specified within the context.
 func UserWrite(ctx Context, users []*types.User) error {
 	// Try handle a custom format, excluding the predefined templates
-	TryFormatUnless(
+	TryFormatUnlessMatches(
 		string(ctx.Format),
 		users,
-		defaultUserQuietFormat,
-		defaultUserTableFormat,
-		`username: {{.Username}}`,
-		`username: {{.Username}}\ngroups: {{.Groups}}\nrole: {{.Role}}\n`,
+		TableMatcher,
+		NewExactMatcher(defaultUserQuietFormat),
+		NewExactMatcher(defaultUserTableFormat),
+		NewExactMatcher(`username: {{.Username}}`),
+		NewExactMatcher(`username: {{.Username}}\ngroups: {{.Groups}}\nrole: {{.Role}}\n`),
 	)
 
 	render := func(format func(subContext subContext) error) error {

--- a/cli/command/formatter/volume.go
+++ b/cli/command/formatter/volume.go
@@ -41,13 +41,14 @@ func NewVolumeFormat(source string, quiet bool) Format {
 // VolumeWrite writes formatted volumes using the Context
 func VolumeWrite(ctx Context, volumes []*types.Volume, nodes []*types.Node) error {
 	// Try handle a custom format, excluding the predefined templates
-	TryFormatUnless(
+	TryFormatUnlessMatches(
 		string(ctx.Format),
 		volumes,
-		defaultVolumeQuietFormat,
-		defaultVolumeTableFormat,
-		`name: {{.Name}}`,
-		`name: {{.Name}}\ndriver: {{.Driver}}\n`,
+		TableMatcher,
+		NewExactMatcher(defaultVolumeQuietFormat),
+		NewExactMatcher(defaultVolumeTableFormat),
+		NewExactMatcher(`name: {{.Name}}`),
+		NewExactMatcher(`name: {{.Name}}\ndriver: {{.Driver}}\n`),
 	)
 
 	render := func(format func(subContext subContext) error) error {

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -69,10 +69,11 @@ func runVersion(storageosCli *command.StorageOSCli, opts *versionOptions) error 
 		Client: version.GetStorageOSVersion(),
 	}
 
-	formatter.TryFormatUnless(
+	formatter.TryFormatUnlessMatches(
 		string(templateFormat),
 		vd,
-		versionTemplate,
+		formatter.TableMatcher,
+		formatter.NewExactMatcher(versionTemplate),
 	)
 
 	tmpl, err := templates.Parse(templateFormat)


### PR DESCRIPTION
Custom table formats were being ignored due to the behaviour of try format unless.

This has been fixed by adding a dynamic matching mechanism to supliment the current solution.