### PR TITLE
fix panic when one node name is shorter than the other

### DIFF
--- a/types/sortable_node_type_test.go
+++ b/types/sortable_node_type_test.go
@@ -1,9 +1,10 @@
 package types_test
 
 import (
+	"testing"
+
 	apiTypes "github.com/storageos/go-api/types"
 	cliTypes "github.com/storageos/go-cli/types"
-	"testing"
 )
 
 func TestSortableNodeTypeCLINodes(t *testing.T) {
@@ -130,6 +131,18 @@ func TestSortableNodeTypeAPINodes(t *testing.T) {
 			nodes:         ns("host-prefix3", "host-prefix2", "host-prefix1", "host-prefix0"),
 			expectError:   false,
 			expectedOrder: []string{"host-prefix0", "host-prefix1", "host-prefix2", "host-prefix3"},
+		},
+		{
+			name:          "caused panic",
+			nodes:         ns("kind-v1.14.3-worker", "kind-v1.14.3-worker2"),
+			expectError:   false,
+			expectedOrder: []string{"kind-v1.14.3-worker", "kind-v1.14.3-worker2"},
+		},
+		{
+			name:          "caused panic reversed",
+			nodes:         ns("kind-v1.14.3-worker2", "kind-v1.14.3-worker"),
+			expectError:   false,
+			expectedOrder: []string{"kind-v1.14.3-worker", "kind-v1.14.3-worker2"},
 		},
 	}
 

--- a/types/types.go
+++ b/types/types.go
@@ -134,10 +134,19 @@ func trimCommonPrefix(a, b string) (string, string) {
 	}
 
 	for i, r := range a {
+
+		// if we've reached the end of b, return empty string,
+		if len(b) <= i {
+			return a[i:], ""
+		}
+
+		// if we have a difference, return the suffixes of both
 		if r != []rune(b)[i] {
 			a, b = a[i:], b[i:]
 			break
 		}
+
+		// or keep looking for a difference
 	}
 
 	return a, b


### PR DESCRIPTION
Fixes panic when node list has a node name shorter then the others:

```
$ kubectl get nodes -o wide
NAME                         STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE       KERNEL-VERSION            CONTAINER-RUNTIME
kind-v1.14.3-control-plane   Ready    master   19m   v1.14.3   172.17.0.4    <none>        Ubuntu 19.04   4.20.11-100.fc28.x86_64   containerd://1.2.6-0ubuntu1
kind-v1.14.3-worker          Ready    <none>   19m   v1.14.3   172.17.0.2    <none>        Ubuntu 19.04   4.20.11-100.fc28.x86_64   containerd://1.2.6-0ubuntu1
kind-v1.14.3-worker2         Ready    <none>   19m   v1.14.3   172.17.0.3    <none>        Ubuntu 19.04   4.20.11-100.fc28.x86_64   containerd://1.2.6-0ubuntu1
```
```
$ ./storageos_linux_amd64-1.2.1 node ls  
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/storageos/go-cli/types.trimCommonPrefix(0xc000029a00, 0x14, 0xc000029800, 0x13, 0x42cd01, 0xc000166b60, 0xc000145b40, 0x478e36)
    /home/simon/go/src/github.com/storageos/go-cli/types/types.go:137 +0x214
github.com/storageos/go-cli/types.HumanisedStringLess(0xc000029a00, 0x14, 0xc000029800, 0x13, 0x203000)
    /home/simon/go/src/github.com/storageos/go-cli/types/types.go:118 +0x59
github.com/storageos/go-cli/types.apiNodeSortFunc.func1(0x1, 0x0, 0xc000166b20)
    /home/simon/go/src/github.com/storageos/go-cli/types/types.go:91 +0x79
sort.insertionSort_func(0xc000166b20, 0xc000166b60, 0x0, 0x2)
    /usr/local/go/src/sort/zfuncversion.go:12 +0xb1
sort.quickSort_func(0xc000166b20, 0xc000166b60, 0x0, 0x2, 0x4)
    /usr/local/go/src/sort/zfuncversion.go:158 +0x1f3
sort.Slice(0x839800, 0xc000166b40, 0xc000166b20)
    /usr/local/go/src/sort/slice.go:21 +0x129
github.com/storageos/go-cli/types.SortAPINodes(0x0, 0xc000166560, 0x2, 0x4, 0x0, 0x0)
    /home/simon/go/src/github.com/storageos/go-cli/types/types.go:73 +0xc0
github.com/storageos/go-cli/cli/command/node.runList(0xc0000a5220, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0)
    /home/simon/go/src/github.com/storageos/go-cli/cli/command/node/list.go:60 +0x16b
github.com/storageos/go-cli/cli/command/node.newListCommand.func1(0xc000159680, 0xcddeb0, 0x0, 0x0, 0x0, 0x0)
    /home/simon/go/src/github.com/storageos/go-cli/cli/command/node/list.go:27 +0x66
github.com/storageos/go-cli/vendor/github.com/dnephin/cobra.(*Command).execute(0xc000159680, 0xc0000201a0, 0x0, 0x0, 0xc000159680, 0xc0000201a0)
    /home/simon/go/src/github.com/storageos/go-cli/vendor/github.com/dnephin/cobra/command.go:646 +0x40d
github.com/storageos/go-cli/vendor/github.com/dnephin/cobra.(*Command).ExecuteC(0xc0000bbb00, 0xc0000bbb00, 0x989380, 0xc000010018)
    /home/simon/go/src/github.com/storageos/go-cli/vendor/github.com/dnephin/cobra/command.go:742 +0x2ca
github.com/storageos/go-cli/vendor/github.com/dnephin/cobra.(*Command).Execute(...)
    /home/simon/go/src/github.com/storageos/go-cli/vendor/github.com/dnephin/cobra/command.go:695
main.main()
    /home/simon/go/src/github.com/storageos/go-cli/cmd/storageos/storageos.go:220 +0xd1
```
